### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: Deploy til nrec


### PR DESCRIPTION
Potential fix for [https://github.com/vuhnger/backend/security/code-scanning/1](https://github.com/vuhnger/backend/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions` block that restricts the `GITHUB_TOKEN` to the least privileges needed. Since this deploy job only connects over SSH and runs commands on a remote server, it does not require any GitHub API access, so we can safely set `permissions: contents: read` (or even `permissions: {}` in some setups). `contents: read` is a common minimal baseline and aligns with GitHub’s recommended starter configuration.

The best fix here is to add a `permissions` block at the workflow root level so it applies to all jobs (there’s only `deploy` currently). We’ll insert it just after the `on:` block and before `jobs:`. Concretely, in `.github/workflows/deploy.yml`, between lines 7 and 8, add:

```yaml
permissions:
  contents: read
```

No imports or other code changes are needed. The rest of the workflow remains the same and functionality (SSH deployment and remote `git pull`) is unaffected, because those operations do not use `GITHUB_TOKEN`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow configuration to enhance security permissions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->