### PR TITLE
feat: Refactor endpoints to expose data by year

### DIFF
--- a/apps/strava/client.py
+++ b/apps/strava/client.py
@@ -3,42 +3,10 @@ Strava API client wrapper using stravalib
 """
 from datetime import datetime, timedelta
 from collections import defaultdict
-from typing import Dict, List, Any
+from typing import Dict, List, Any, Optional
 from stravalib.client import Client
 from sqlalchemy.orm import Session
 from apps.strava.utils import get_valid_token
-
-
-def get_ytd_stats(db: Session) -> Dict[str, Dict[str, Any]]:
-    """
-    Fetch year-to-date statistics from Strava.
-    Returns: dict with counts, distances, times, elevation
-    """
-    access_token = get_valid_token(db)
-    client = Client(access_token=access_token)
-
-    # Get athlete stats
-    athlete = client.get_athlete()
-    stats = client.get_athlete_stats(athlete.id)
-
-    # Extract YTD totals
-    ytd_run = stats.ytd_run_totals
-    ytd_ride = stats.ytd_ride_totals
-
-    return {
-        "run": {
-            "count": ytd_run.count,
-            "distance": float(ytd_run.distance),  # meters
-            "moving_time": int(ytd_run.moving_time.total_seconds()) if ytd_run.moving_time else 0,  # seconds
-            "elevation_gain": float(ytd_run.elevation_gain)  # meters
-        },
-        "ride": {
-            "count": ytd_ride.count,
-            "distance": float(ytd_ride.distance),
-            "moving_time": int(ytd_ride.moving_time.total_seconds()) if ytd_ride.moving_time else 0,  # seconds
-            "elevation_gain": float(ytd_ride.elevation_gain)
-        }
-    }
 
 
 def get_recent_activities(db: Session, limit: int = 30) -> List[Dict[str, Any]]:
@@ -112,16 +80,21 @@ def get_monthly_stats(db: Session, months: int = 12) -> Dict[str, Dict[str, Any]
     return result
 
 
-def get_all_activities(db: Session, limit: int = None):
+def get_all_activities(db: Session, after: Optional[datetime] = None, limit: int = None):
     """
-    Fetch all historic activities from Strava.
+    Fetch activities from Strava, optionally after a given date.
     Yields activity data dictionaries suitable for StravaActivity model.
+
+    Args:
+        db: Database session for token access
+        after: Only fetch activities after this datetime (server-side filter)
+        limit: Maximum number of activities to fetch (None for all)
     """
     access_token = get_valid_token(db)
     client = Client(access_token=access_token)
 
-    # Get all activities (paginated automatically by stravalib)
-    activities = client.get_activities(limit=limit)
+    # Get activities (paginated automatically by stravalib)
+    activities = client.get_activities(after=after, limit=limit)
 
     for activity in activities:
         yield {

--- a/apps/strava/client.py
+++ b/apps/strava/client.py
@@ -3,7 +3,7 @@ Strava API client wrapper using stravalib
 """
 from datetime import datetime, timedelta
 from collections import defaultdict
-from typing import Dict, List, Any, Optional
+from typing import Dict, List, Any, Optional, Generator
 from stravalib.client import Client
 from sqlalchemy.orm import Session
 from apps.strava.utils import get_valid_token
@@ -80,7 +80,7 @@ def get_monthly_stats(db: Session, months: int = 12) -> Dict[str, Dict[str, Any]
     return result
 
 
-def get_all_activities(db: Session, after: Optional[datetime] = None, limit: Optional[int] = None):
+def get_all_activities(db: Session, after: Optional[datetime] = None, limit: Optional[int] = None) -> Generator[Dict[str, Any], None, None]:
     """
     Fetch activities from Strava, optionally after a given date.
     Yields activity data dictionaries suitable for StravaActivity model.

--- a/apps/strava/client.py
+++ b/apps/strava/client.py
@@ -80,7 +80,7 @@ def get_monthly_stats(db: Session, months: int = 12) -> Dict[str, Dict[str, Any]
     return result
 
 
-def get_all_activities(db: Session, after: Optional[datetime] = None, limit: int = None):
+def get_all_activities(db: Session, after: Optional[datetime] = None, limit: Optional[int] = None):
     """
     Fetch activities from Strava, optionally after a given date.
     Yields activity data dictionaries suitable for StravaActivity model.

--- a/apps/strava/constants.py
+++ b/apps/strava/constants.py
@@ -1,10 +1,11 @@
 """
 Strava service constants
 """
-from datetime import datetime
+from datetime import datetime, timezone
 
 # Minimum year for stats - no data before 2024 is synced or queryable
 MIN_YEAR = 2024
 
-# Cutoff date for activity sync (start of MIN_YEAR)
-ACTIVITY_CUTOFF = datetime(MIN_YEAR, 1, 1)
+# Cutoff date for activity sync (start of MIN_YEAR, UTC)
+# Using timezone-aware datetime since Strava API works with UTC timestamps
+ACTIVITY_CUTOFF = datetime(MIN_YEAR, 1, 1, tzinfo=timezone.utc)

--- a/apps/strava/constants.py
+++ b/apps/strava/constants.py
@@ -1,0 +1,10 @@
+"""
+Strava service constants
+"""
+from datetime import datetime
+
+# Minimum year for stats - no data before 2024 is synced or queryable
+MIN_YEAR = 2024
+
+# Cutoff date for activity sync (start of MIN_YEAR)
+ACTIVITY_CUTOFF = datetime(MIN_YEAR, 1, 1)

--- a/apps/strava/main.py
+++ b/apps/strava/main.py
@@ -7,6 +7,7 @@ Single user mode - stores one set of tokens and serves cached data.
 import os
 import logging
 from datetime import datetime
+from typing import Optional
 from fastapi import FastAPI, APIRouter, Depends, HTTPException
 from fastapi.responses import RedirectResponse, FileResponse
 from sqlalchemy.orm import Session
@@ -27,7 +28,7 @@ logger = logging.getLogger(__name__)
 from fastapi.openapi.docs import get_swagger_ui_html
 
 
-def validate_year(year: int, allow_none: bool = False) -> int:
+def validate_year(year: Optional[int], allow_none: bool = False) -> int:
     """
     Validate year parameter against MIN_YEAR and current year.
     Returns validated year, defaulting to current year if None and allowed.

--- a/apps/strava/tasks.py
+++ b/apps/strava/tasks.py
@@ -69,13 +69,12 @@ def sync_activities(db: Session):
 
     for activity_data in activities_gen:
         batch.append(activity_data)
-        
+        count += 1
+
         if len(batch) >= BATCH_SIZE:
             _bulk_upsert_activities(db, batch)
             batch = []
-            logger.info(f"Synced {count + BATCH_SIZE} activities...")
-        
-        count += 1
+            logger.info(f"Synced {count} activities...")
 
     if batch:
         _bulk_upsert_activities(db, batch)

--- a/apps/strava/tasks.py
+++ b/apps/strava/tasks.py
@@ -2,19 +2,16 @@
 Background tasks for fetching and caching Strava data
 """
 import logging
-from datetime import datetime
 from typing import Dict, Any, List
 from sqlalchemy.orm import Session
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from apps.shared.database import SessionLocal
 from apps.strava.models import StravaStats, StravaActivity
 from apps.strava.client import get_recent_activities, get_monthly_stats, get_all_activities
+from apps.strava.constants import ACTIVITY_CUTOFF
 from apps.shared.upsert import atomic_upsert_stats
 
 logger = logging.getLogger(__name__)
-
-# Only sync activities from 2024 onwards
-ACTIVITY_CUTOFF = datetime(2024, 1, 1)
 
 
 def fetch_and_cache_stats():

--- a/apps/strava/tasks.py
+++ b/apps/strava/tasks.py
@@ -70,11 +70,13 @@ def sync_activities(db: Session):
 
         if len(batch) >= BATCH_SIZE:
             _bulk_upsert_activities(db, batch)
+            db.flush()  # Persist to DB but keep transaction open
             batch = []
             logger.info(f"Synced {count} activities...")
 
     if batch:
         _bulk_upsert_activities(db, batch)
+        db.flush()
     
     logger.info(f"Total activities synced: {count}")
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added /stats/summary/{year} endpoint with year validation (2024+), explicit "no activities found" responses, and richer activity payloads (elapsed time, elevation gain, local start date/timezone, speeds, heart rates, kudos).
* **Refactor**
  * Summarized endpoints now aggregate live per-year activity data instead of cached YTD stats.
  * Syncing now targets activities from 2024+, using batching, brief inter-batch delays, and improved logging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->