### PR TITLE
CI: unit + regression tests, ruff linting, deploy gated on green build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  # Cancel superseded runs on the same ref (saves CI minutes on rapid pushes).
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint (ruff)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Sync dependencies
+        run: uv sync --frozen
+      - name: Ruff (correctness rules)
+        run: uv run ruff check .
+
+  test:
+    name: Tests (pytest)
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: backend_user
+          POSTGRES_DB: backend_db
+          # Ephemeral, localhost-only CI database: accept local connections with
+          # no password. Means there is no credential anywhere to hardcode.
+          POSTGRES_HOST_AUTH_METHOD: trust
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U backend_user"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      ENVIRONMENT: development
+      # Passwordless DSN — the CI Postgres uses trust auth (see service above).
+      DATABASE_URL: postgresql+psycopg2://backend_user@localhost:5432/backend_db
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Sync dependencies (incl. dev)
+        run: uv sync --frozen
+      - name: Generate throwaway test secrets
+        # The apps only need these set to boot; values are irrelevant to the
+        # tests. Generated at runtime so no secret-shaped literal is committed.
+        run: |
+          {
+            echo "ENCRYPTION_KEY=$(openssl rand -hex 16)"
+            echo "STATE_SECRET=$(openssl rand -hex 16)"
+            echo "INTERNAL_API_KEY=$(openssl rand -hex 16)"
+          } >> "$GITHUB_ENV"
+      - name: Run tests
+        run: uv run pytest -q

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,13 @@
 name: Deploy til server
 
+# Deploy only after CI succeeds on main — a red build must never reach the
+# server. workflow_run fires when the "CI" workflow finishes; the job guard
+# below restricts it to successful runs triggered by a push to main.
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
 
 permissions:
   contents: read
@@ -12,6 +16,10 @@ jobs:
   deploy:
     name: Deploy til nrec
     runs-on: ubuntu-latest
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main'
 
     steps:
       - name: Deploy via SSH

--- a/.gitignore
+++ b/.gitignore
@@ -133,5 +133,11 @@ test_*.py
 *_test.py
 benchmark_*.py
 
+# ...but always track the real test suite's Python sources (CI runs it).
+# Scoped to *.py so __pycache__/*.pyc stays ignored via *.py[cod] above.
+!tests/
+!tests/*.py
+!tests/**/*.py
+
 refresh.sh
 n8n-workflows/*

--- a/apps/projects/models.py
+++ b/apps/projects/models.py
@@ -3,7 +3,6 @@ Projects database models.
 
 Stores project information including metadata, images, and links.
 """
-from datetime import datetime
 from sqlalchemy import Column, Integer, String, Text, Boolean, DateTime, func
 from sqlalchemy.dialects.postgresql import JSONB
 

--- a/apps/strava/main.py
+++ b/apps/strava/main.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from fastapi import FastAPI, APIRouter, Depends, HTTPException
 from fastapi.responses import RedirectResponse, FileResponse
 from sqlalchemy.orm import Session
-from sqlalchemy import desc, extract
+from sqlalchemy import desc, extract, func
 from stravalib.client import Client
 
 from apps.shared.database import get_db, Base, engine, check_db_connection
@@ -303,15 +303,13 @@ def get_all_time_totals(db: Session = Depends(get_db)):
     """
     Get all-time totals for each activity type.
     """
-    from sqlalchemy import sum
-
     results = (
         db.query(
             StravaActivity.type,
             func.count(StravaActivity.id).label("count"),
-            sum(StravaActivity.distance).label("distance"),
-            sum(StravaActivity.moving_time).label("moving_time"),
-            sum(StravaActivity.total_elevation_gain).label("elevation_gain"),
+            func.sum(StravaActivity.distance).label("distance"),
+            func.sum(StravaActivity.moving_time).label("moving_time"),
+            func.sum(StravaActivity.total_elevation_gain).label("elevation_gain"),
         )
         .group_by(StravaActivity.type)
         .all()
@@ -337,8 +335,6 @@ def get_yearly_stats(db: Session = Depends(get_db)):
     """
     Get activity totals grouped by year and type.
     """
-    from sqlalchemy import sum
-
     year_col = extract("year", StravaActivity.start_date_local)
 
     results = (
@@ -346,9 +342,9 @@ def get_yearly_stats(db: Session = Depends(get_db)):
             year_col.label("year"),
             StravaActivity.type,
             func.count(StravaActivity.id).label("count"),
-            sum(StravaActivity.distance).label("distance"),
-            sum(StravaActivity.moving_time).label("moving_time"),
-            sum(StravaActivity.total_elevation_gain).label("elevation_gain"),
+            func.sum(StravaActivity.distance).label("distance"),
+            func.sum(StravaActivity.moving_time).label("moving_time"),
+            func.sum(StravaActivity.total_elevation_gain).label("elevation_gain"),
         )
         .group_by(year_col, StravaActivity.type)
         .order_by(desc("year"), StravaActivity.type)

--- a/apps/wakatime/client.py
+++ b/apps/wakatime/client.py
@@ -2,7 +2,7 @@
 WakaTime API client wrapper
 """
 import logging
-from datetime import datetime, date
+from datetime import date
 import requests
 from sqlalchemy.orm import Session
 from apps.wakatime.utils import get_valid_token

--- a/apps/wakatime/tasks.py
+++ b/apps/wakatime/tasks.py
@@ -2,7 +2,6 @@
 Background tasks for fetching and caching WakaTime data
 """
 import logging
-from sqlalchemy.orm import Session
 from apps.shared.database import SessionLocal
 from apps.wakatime.models import WakaTimeStats, WakaTimeAuth
 from apps.wakatime.client import get_stats, get_today_summary, get_weekly_summary

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,14 +22,33 @@ dependencies = [
 ]
 
 [dependency-groups]
-# Test tooling. pytest-asyncio must track pytest's major line — 0.23.x caps at
-# pytest<9, which is what broke the old requirements.txt. >=1.0 supports pytest 9.
+# Test + lint tooling. pytest-asyncio must track pytest's major line — 0.23.x
+# caps at pytest<9, which is what broke the old requirements.txt. >=1.0 supports
+# pytest 9.
 dev = [
     "pytest==9.0.3",
     "pytest-asyncio>=1.0",
+    "ruff>=0.6",
 ]
 
 [tool.uv]
 # The apps are run as modules (uvicorn apps.x.main:app) from the source tree,
 # not installed as a distribution — so only resolve/install dependencies.
 package = false
+
+[tool.pytest.ini_options]
+# Run from the repo root so `import apps.…` resolves without installing the pkg.
+pythonpath = ["."]
+testpaths = ["tests"]
+# Let pytest-asyncio pick up `async def test_*` without per-test markers.
+asyncio_mode = "auto"
+
+[tool.ruff]
+line-length = 120
+target-version = "py311"
+
+[tool.ruff.lint]
+# Start enforceable and correctness-focused: pyflakes (undefined names, unused
+# imports — real breakage) + syntax errors. Style/upgrade rules can be added
+# later without blocking CI on pre-existing formatting choices.
+select = ["F", "E9"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+"""Shared test setup.
+
+The app modules read a few env vars at import time (notably DATABASE_URL, which
+`apps.shared.database` requires to build the engine). Set harmless defaults so
+tests can import the apps without a real environment. `setdefault` means CI's
+real values (e.g. a live Postgres service) always win.
+"""
+
+import os
+import secrets
+
+# No password in the default DSN — it's only used for import (create_engine is
+# lazy) when DATABASE_URL is unset locally; CI sets a real one. Keeping it
+# credential-free avoids committing a `user:password@host` string.
+os.environ.setdefault(
+    "DATABASE_URL",
+    "postgresql+psycopg2://backend_user@localhost:5432/backend_db",
+)
+# These just need to be set for the apps to import/boot; the tests don't rely on
+# their values. Generate ephemeral ones so no secret-shaped literal is committed.
+os.environ.setdefault("ENCRYPTION_KEY", secrets.token_hex(16))
+os.environ.setdefault("STATE_SECRET", secrets.token_hex(16))
+os.environ.setdefault("INTERNAL_API_KEY", secrets.token_hex(16))
+os.environ.setdefault("ENVIRONMENT", "development")

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,39 @@
+"""DB-backed regression: the strava app boots against Postgres, its health
+endpoint reports a live connection, and security headers apply to a DB-backed
+service too.
+
+Skips when no database is reachable so the header tests above can still run
+locally without spinning up Postgres. CI provides a Postgres service, so these
+execute there.
+"""
+
+import pytest
+
+from fastapi.testclient import TestClient
+
+from apps.shared.database import check_db_connection
+
+
+@pytest.fixture(scope="module")
+def strava_client():
+    if not check_db_connection():
+        pytest.skip("no database reachable (set DATABASE_URL to a live Postgres)")
+    # Imported lazily: apps.strava.main runs create_all() at import, which needs
+    # a live connection — only reached once we know the DB is up.
+    from apps.strava.main import app
+
+    return TestClient(app)
+
+
+def test_strava_health_reports_connected(strava_client):
+    r = strava_client.get("/strava/health")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "ok"
+    assert body["database"] == "connected"
+
+
+def test_security_headers_on_db_backed_app(strava_client):
+    r = strava_client.get("/strava/openapi.json")
+    assert r.headers["x-frame-options"] == "DENY"
+    assert "script-src 'self';" in r.headers["content-security-policy"]

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -1,0 +1,42 @@
+"""Regression guards for the security-header + local-Swagger hardening.
+
+Uses the n8n app: it needs no database, so these run with no external services.
+"""
+
+from fastapi.testclient import TestClient
+
+from apps.n8n.main import app
+
+client = TestClient(app)
+
+
+def test_all_security_headers_present():
+    r = client.get("/n8n/openapi.json")
+    assert r.status_code == 200
+    assert r.headers["x-frame-options"] == "DENY"
+    assert r.headers["x-content-type-options"] == "nosniff"
+    assert "max-age=31536000" in r.headers["strict-transport-security"]
+    assert r.headers["cache-control"] == "no-cache, no-store, must-revalidate"
+
+
+def test_global_csp_is_strict():
+    # Regular API responses must NOT allow inline scripts. The global policy is
+    # "…; script-src 'self'; …" — the trailing ';' proves nothing follows 'self'.
+    csp = client.get("/n8n/openapi.json").headers["content-security-policy"]
+    assert "script-src 'self';" in csp
+    assert "'unsafe-inline'" not in csp.split("script-src")[1].split(";")[0]
+
+
+def test_docs_served_locally_with_scoped_csp():
+    r = client.get("/n8n/docs")
+    assert r.status_code == 200
+    # Swagger assets come from /static, never a third-party CDN.
+    assert "/static/swagger-ui/swagger-ui-bundle.js" in r.text
+    assert "cdn.jsdelivr.net" not in r.text
+    # The inline-script relaxation Swagger needs is scoped to the docs response.
+    assert "script-src 'self' 'unsafe-inline'" in r.headers["content-security-policy"]
+
+
+def test_redoc_disabled():
+    # redoc_url=None — no ReDoc route pulling external assets.
+    assert client.get("/redoc").status_code == 404

--- a/tests/test_wakatime.py
+++ b/tests/test_wakatime.py
@@ -1,0 +1,44 @@
+from unittest.mock import MagicMock, patch
+
+from apps.wakatime.tasks import fetch_and_cache_wakatime_stats
+from apps.wakatime.models import WakaTimeAuth
+
+
+@patch("apps.wakatime.tasks.atomic_upsert_stats")
+@patch("apps.wakatime.tasks.get_stats")
+@patch("apps.wakatime.tasks.get_weekly_summary")
+@patch("apps.wakatime.tasks.get_today_summary")
+@patch("apps.wakatime.tasks.SessionLocal")
+def test_fetch_and_cache_wakatime_stats(
+    mock_session_local, mock_today, mock_weekly, mock_stats, mock_upsert
+):
+    # Arrange: a session whose auth lookup returns an existing row.
+    mock_session = MagicMock()
+    mock_session_local.return_value = mock_session
+    mock_session.query.return_value.first.return_value = WakaTimeAuth(
+        id=1, user_id="test"
+    )
+
+    mock_today.return_value = {"grand_total": {"total_seconds": 3600}}
+    mock_weekly.return_value = {"languages": []}
+    mock_stats.return_value = {"total_seconds": 100000}
+
+    # Act
+    fetch_and_cache_wakatime_stats()
+
+    # Assert: each source is fetched exactly once (all_time via get_stats).
+    mock_today.assert_called_once()
+    mock_weekly.assert_called_once()
+    mock_stats.assert_called_once_with(mock_session, "all_time")
+
+    # Three cache writes, in order, keyed today / last_7_days / all_time.
+    assert mock_upsert.call_count == 3
+    unique_values = [c.kwargs["unique_value"] for c in mock_upsert.call_args_list]
+    assert unique_values == ["today", "last_7_days", "all_time"]
+
+    # The "today" payload is passed through and tagged with its range label.
+    today_data = mock_upsert.call_args_list[0].kwargs["update_data"]["data"]
+    assert today_data["grand_total"] == {"total_seconds": 3600}
+    assert today_data["range"] == "today"
+
+    assert mock_session.commit.called

--- a/uv.lock
+++ b/uv.lock
@@ -58,6 +58,7 @@ dependencies = [
 dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -78,6 +79,7 @@ requires-dist = [
 dev = [
     { name = "pytest", specifier = "==9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.0" },
+    { name = "ruff", specifier = ">=0.6" },
 ]
 
 [[package]]
@@ -523,6 +525,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652", size = 134232, upload-time = "2026-03-25T15:10:41.586Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b", size = 65017, upload-time = "2026-03-25T15:10:40.382Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why
`main` had **no test/lint CI** and **auto-deployed on every push** — nothing stopped a broken build from reaching the server. The one existing test wasn't even collectable (no `pythonpath` config), so it never ran.

## What
### `ci.yml` (runs on PRs + pushes to main)
- **lint**: `ruff check` with correctness rules (`F` + `E9`) — undefined names, unused imports. Scoped to real-breakage rules, not style, so it's enforceable without a mass reformat.
- **test**: `pytest` against a **Postgres service**, so DB-backed tests run for real.

### Deploy gated on CI
`deploy.yml` now triggers via `workflow_run` and only deploys when **CI succeeded on a push to main**. A red build no longer reaches nrec.

### Tests
| File | Covers | DB? |
|---|---|---|
| `test_security_headers.py` | headers present, strict global CSP, docs served locally, `/redoc` 404 | no |
| `test_health.py` | strava boots against Postgres, `/health` reports connected | yes (skips if none) |
| `test_wakatime.py` | rewired to current `tasks.py` (old mocks were stale) | no |

Plus `pyproject` config (`pythonpath`, `asyncio_mode`, ruff) and `conftest.py` env defaults.

## Bugs the linter caught (fixed here)
- **`apps/strava/main.py`**: `func` was never imported (`NameError`) and `from sqlalchemy import sum` is invalid — **`/stats/all-time` and `/stats/yearly` were dead**. Now use `func.count` / `func.sum`.
- Removed unused imports in `projects/models`, `wakatime/client`, `wakatime/tasks`.

## Verified locally
- Full suite in a container with Postgres: **7 passed**.
- Without a DB: **5 passed, 2 skipped** (health tests skip gracefully).
- `ruff check .` clean; both workflows parse.