### PR TITLE
perf(db): connection pooling (QueuePool + pre-ping)

### DIFF
--- a/apps/shared/database.py
+++ b/apps/shared/database.py
@@ -8,7 +8,6 @@ NO models are defined here - this is just infrastructure.
 import os
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker, declarative_base
-from sqlalchemy.pool import NullPool
 
 # Get database URL from environment variable
 DATABASE_URL = os.getenv("DATABASE_URL")
@@ -19,11 +18,31 @@ if not DATABASE_URL:
         "Example: postgresql+psycopg2://user:password@host:5432/database"
     )
 
-# Create engine
-# Using NullPool for better compatibility with containerized environments
+
+def _int_env(name: str, default: int) -> int:
+    """Read a positive-int tuning knob from the environment, falling back safely."""
+    try:
+        return int(os.getenv(name, default))
+    except (TypeError, ValueError):
+        return default
+
+
+# Create engine with SQLAlchemy's default QueuePool instead of NullPool.
+# NullPool opened a fresh TCP + auth handshake on every request; a real pool keeps
+# a small set of warm connections, which is the single biggest per-request win here.
+#   - pool_pre_ping: cheaply validate a connection before use, so a Postgres
+#     restart or an idle-timeout drop surfaces as a transparent reconnect instead
+#     of the first query after the gap failing.
+#   - pool_recycle: proactively retire connections older than this (seconds) to
+#     stay under server-side / proxy idle limits.
+# All knobs are env-overridable so a low-memory host can shrink the pool.
 engine = create_engine(
     DATABASE_URL,
-    poolclass=NullPool,
+    pool_size=_int_env("DB_POOL_SIZE", 5),
+    max_overflow=_int_env("DB_MAX_OVERFLOW", 10),
+    pool_timeout=_int_env("DB_POOL_TIMEOUT", 30),
+    pool_recycle=_int_env("DB_POOL_RECYCLE", 1800),
+    pool_pre_ping=True,
     echo=False,  # Set to True for SQL query logging during development
 )
 


### PR DESCRIPTION
## What
Replace `NullPool` with SQLAlchemy's default `QueuePool` in `apps/shared/database.py`.

## Why
`NullPool` opened a fresh TCP + auth handshake on **every request**. A warm pool is the single biggest per-request latency win for the DB-backed apps, and matches the project's stated preference for connection pooling.

## Changes
- `QueuePool` (SQLAlchemy default) with `pool_pre_ping=True` — a Postgres restart or idle-timeout drop now reconnects transparently instead of failing the first query after the gap.
- `pool_recycle=1800` retires connections before server/proxy idle limits.
- Pool knobs (`DB_POOL_SIZE`, `DB_MAX_OVERFLOW`, `DB_POOL_TIMEOUT`, `DB_POOL_RECYCLE`) are env-overridable so a low-memory host can shrink the pool.

## Verification
- `ruff` clean.
- Live test against dev Postgres: `pool class: QueuePool`, `pre_ping: True`; two sequential connections reuse one pooled conn (`checkedin: 1`), proving no per-request reconnect.
- Full test suite: **7 passed**.

Part of the post-audit hardening sweep (fix #8).