### PR TITLE
ci(deploy): registry-based deploy (GHCR, no-downtime roll)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,8 @@
 name: Deploy til server
 
 # Deploy only after CI succeeds on main — a red build must never reach the
-# server. workflow_run fires when the "CI" workflow finishes; the job guard
-# below restricts it to successful runs triggered by a push to main.
+# server. workflow_run fires when the "CI" workflow finishes; the job guards
+# below restrict it to successful runs triggered by a push to main.
 on:
   workflow_run:
     workflows: ["CI"]
@@ -11,16 +11,55 @@ on:
 
 permissions:
   contents: read
+  packages: write # push the image to GHCR
+
+env:
+  IMAGE: ghcr.io/${{ github.repository }} # ghcr.io/vuhnger/backend
 
 jobs:
-  deploy:
-    name: Deploy til nrec
+  # 1) Build the image once, in CI, and push it to GHCR. The server no longer
+  #    builds on the production host (slow, non-reproducible, competes for RAM).
+  build-and-push:
+    name: Build & push image
     runs-on: ubuntu-latest
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.head_branch == 'main'
+    outputs:
+      sha: ${{ github.event.workflow_run.head_sha }}
+    steps:
+      - name: Checkout the exact commit CI validated
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
 
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          # Tag with the immutable commit SHA (for rollback) and moving `latest`
+          # (what the compose file pulls by default).
+          tags: |
+            ${{ env.IMAGE }}:${{ github.event.workflow_run.head_sha }}
+            ${{ env.IMAGE }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # 2) Pull the freshly built image on the server and roll the services. No
+  #    `down`, no `--build`: `up -d` recreates only changed containers.
+  deploy:
+    name: Deploy til nrec
+    needs: build-and-push
+    runs-on: ubuntu-latest
     steps:
       - name: Deploy via SSH
         uses: appleboy/ssh-action@v1.0.3
@@ -29,9 +68,16 @@ jobs:
           username: ${{ secrets.SSH_USERNAME }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           port: ${{ secrets.SSH_PORT || 22 }}
+          # BACKEND_TAG defaults to `latest`; set it to a SHA to pin/rollback.
           script: |
+            set -euo pipefail
             cd backend
             git pull origin main
-            docker compose down
-            docker compose up -d --build
-            docker compose logs --tail=50
+            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+            docker compose pull
+            # Apply DB migrations before starting the new code (see alembic/README
+            # for the one-time `alembic stamp head` needed to adopt Alembic).
+            docker compose run --rm strava-api alembic upgrade head
+            docker compose up -d
+            docker image prune -f
+            docker compose ps

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       retries: 5
 
   strava-api:
-    build: .
+    image: ghcr.io/vuhnger/backend:${BACKEND_TAG:-latest}
     command: ["uvicorn", "apps.strava.main:app", "--host", "0.0.0.0", "--port", "5001"]
     restart: unless-stopped
     ports:
@@ -48,7 +48,7 @@ services:
       - backend
 
   n8n-api:
-    build: .
+    image: ghcr.io/vuhnger/backend:${BACKEND_TAG:-latest}
     command: ["uvicorn", "apps.n8n.main:app", "--host", "0.0.0.0", "--port", "5004"]
     restart: unless-stopped
     ports:
@@ -59,7 +59,7 @@ services:
       - backend
 
   wakatime-api:
-    build: .
+    image: ghcr.io/vuhnger/backend:${BACKEND_TAG:-latest}
     command: ["uvicorn", "apps.wakatime.main:app", "--host", "0.0.0.0", "--port", "5002"]
     restart: unless-stopped
     ports:
@@ -81,7 +81,7 @@ services:
       - backend
 
   projects-api:
-    build: .
+    image: ghcr.io/vuhnger/backend:${BACKEND_TAG:-latest}
     command: ["uvicorn", "apps.projects.main:app", "--host", "0.0.0.0", "--port", "5005"]
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## What
Build the image once in CI, push to **GHCR**, and have the server **pull + roll** instead of building on-host and taking everything down.

## Why
Today's deploy runs `git pull && docker compose down && up -d --build` on the production host:
- **Downtime** — every service stops during the rebuild.
- **Build-on-prod** — slow, non-reproducible, competes with the live app for RAM.
- **No rollback** — the previous image is gone once rebuilt.

## Changes
- `deploy.yml`: `build-and-push` job builds from the exact CI'd commit (`workflow_run.head_sha`) and pushes `ghcr.io/vuhnger/backend` tagged with the **commit SHA** (immutable, for rollback) and **`latest`** (what compose pulls). GHA build cache. Then a `deploy` job SSHes in and runs `pull → alembic upgrade head → up -d` — no `down`, no `--build`.
- `docker-compose.yml` (prod): all four app services use `image: ghcr.io/vuhnger/backend:${BACKEND_TAG:-latest}` instead of `build: .`. Set `BACKEND_TAG=<sha>` to pin/rollback.

## Verification
- `deploy.yml` parses; `docker compose -f docker-compose.yml config` is valid and shows the image refs applied (no `build:` left).
- The build/push/SSH path itself can only be verified by a real run — see below.

## ⚠️ Operational requirements (please review before merging)
1. **Merge after #57 (Alembic).** The deploy runs `alembic upgrade head`; that needs the Alembic PR merged, and a one-time `alembic stamp head` on the prod DB (see alembic/README).
2. **GHCR access on the server:** the SSH script does `docker login ghcr.io` with `GITHUB_TOKEN`. If the package is private, confirm the server can pull; simplest is to make the `backend` package public, or keep the login step.
3. **First deploy:** watch the run — I can't exercise the GHCR push or the SSH deploy from here.

Part of the post-audit hardening sweep (fix #11).