### PR TITLE
ci(security): pin actions to SHAs + fix Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,17 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
+# Dependabot version updates.
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  # Keep GitHub Actions fresh. Because the workflows pin actions to commit SHAs,
+  # this is what raises PRs to move those pins forward (and the "# vX" comment
+  # keeps them readable).
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+
+  # Python dependencies (pyproject.toml + uv.lock).
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
     name: Lint (ruff)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           enable-cache: true
       - name: Sync dependencies
@@ -52,9 +52,9 @@ jobs:
       # Passwordless DSN — the CI Postgres uses trust auth (see service above).
       DATABASE_URL: postgresql+psycopg2://backend_user@localhost:5432/backend_db
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           enable-cache: true
       - name: Sync dependencies (incl. dev)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,19 +30,19 @@ jobs:
       sha: ${{ github.event.workflow_run.head_sha }}
     steps:
       - name: Checkout the exact commit CI validated
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           push: true
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Deploy via SSH
-        uses: appleboy/ssh-action@v1.0.3
+        uses: appleboy/ssh-action@029f5b4aeeeb58fdfe1410a5d17f967dacf36262 # v1.0.3
         with:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USERNAME }}


### PR DESCRIPTION
> **Stacked on #58** (deploy). Base is `ci/deploy-registry`.

## What
Pin every GitHub Action to an immutable **commit SHA**, and repair the broken Dependabot config so the pins stay maintained.

## Why
- Tags like `@v4` / `@v1.0.3` are **mutable** — if an action's tag is moved or its repo is compromised, that code runs in CI with access to repo secrets (incl. `SSH_PRIVATE_KEY`, `GITHUB_TOKEN`). SHA pinning removes that class of supply-chain risk.
- `dependabot.yml` was the default **stub** (`package-ecosystem: ""`, which is invalid) — version updates never ran. Pinning without a bump mechanism just rots; fixing Dependabot is the other half of this.

## Changes
- All `uses:` in `ci.yml` + `deploy.yml` now `@<40-char-sha> # vX`:
  - `actions/checkout@11d5960…` # v4
  - `astral-sh/setup-uv@d4b2f3b…` # v5
  - `docker/login-action@c94ce9f…` # v3
  - `docker/build-push-action@10e90e3…` # v6
  - `appleboy/ssh-action@029f5b4…` # v1.0.3
- `dependabot.yml`: real config — `github-actions` (weekly; raises PRs to advance the SHA pins) + `uv` (Python deps).

## Verification
- SHAs resolved from each action repo's tag via the GitHub API.
- Both workflows + dependabot.yml parse as valid YAML; grep confirms no bare `@vN` refs remain.

## Note
Confirm GitHub accepts the `uv` Dependabot ecosystem on first run (it's supported, but easy to verify in the Insights → Dependency graph → Dependabot tab).

Part of the post-audit hardening sweep (fix #12).