### PR TITLE
ci(deploy): drop GHA build cache (fixes failing build step)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,8 +51,6 @@ jobs:
           tags: |
             ${{ env.IMAGE }}:${{ github.event.workflow_run.head_sha }}
             ${{ env.IMAGE }}:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
   # 2) Pull the freshly built image on the server and roll the services. No
   #    `down`, no `--build`: `up -d` recreates only changed containers.


### PR DESCRIPTION
The deploy build step failed with `Cache export is not supported for the docker driver` — `cache-to: type=gha` requires a buildx container driver that isn't set up. The GHA cache is only a build-speed optimization; removing it lets the default docker driver build + push reliably. Verified the deploy build failure in run 30116580636.

Unblocks the first real registry deploy.