### PR TITLE
harden: projects app + CORS (audit #2/#3/#4/#5)

### DIFF
--- a/apps/projects/main.py
+++ b/apps/projects/main.py
@@ -6,14 +6,15 @@ CRUD endpoints for portfolio projects with image upload support.
 import os
 import logging
 import aiofiles
+import filetype
 from uuid import uuid4
-from fastapi import FastAPI, APIRouter, Depends, HTTPException, UploadFile, File
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, File
 from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
 
 from apps.shared.database import get_db, check_db_connection
 from apps.shared.auth import get_api_key
-from apps.shared.cors import setup_cors
+from apps.shared.app_factory import create_app
 from apps.projects.models import Project
 from apps.projects.schemas import (
     ProjectCreate,
@@ -33,16 +34,13 @@ UPLOAD_BASE_URL = os.getenv("UPLOAD_BASE_URL", "https://api.vuhnger.dev/uploads/
 ALLOWED_TYPES = {"image/jpeg", "image/png", "image/webp", "image/gif"}
 MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB
 
-app = FastAPI(
+# Hardened app: CORS, cache-control, security headers, and locally-served docs
+# (matches the other services; a strict CSP would block CDN-hosted Swagger).
+app = create_app(
     title="Projects API",
-    version="1.0.0",
+    url_prefix="projects",
     description="Portfolio projects management with image uploads",
-    docs_url="/projects/docs",
-    openapi_url="/projects/openapi.json",
 )
-
-# Setup CORS from shared configuration
-setup_cors(app)
 
 router = APIRouter(prefix="/projects", tags=["projects"])
 
@@ -87,6 +85,19 @@ def list_featured_projects(db: Session = Depends(get_db)):
         .all()
     )
     return projects
+
+
+@router.get("/admin", include_in_schema=False)
+def admin_panel():
+    """Serve the admin panel HTML.
+
+    Registered before the /{slug} route below — otherwise FastAPI matches the
+    dynamic route first and 'admin' is swallowed as a project slug (404).
+    """
+    admin_path = os.path.join(os.path.dirname(__file__), "..", "..", "static", "admin.html")
+    if not os.path.exists(admin_path):
+        raise HTTPException(status_code=404, detail="Admin panel not found")
+    return FileResponse(admin_path)
 
 
 @router.get("/{slug}", response_model=ProjectResponse)
@@ -204,24 +215,36 @@ async def upload_image(
     Upload an image for a project.
     Returns the public URL of the uploaded image.
     """
-    # Validate file type
+    too_large = f"File too large. Max size: {MAX_FILE_SIZE // (1024 * 1024)} MB"
+
+    # Reject oversized uploads before buffering the whole body into memory.
+    # UploadFile.size comes from the multipart part length when the client sends it.
+    if file.size is not None and file.size > MAX_FILE_SIZE:
+        raise HTTPException(status_code=400, detail=too_large)
+
+    # The declared content-type is client-controlled; treat it as a first filter
+    # only, then confirm against the real bytes below.
     if file.content_type not in ALLOWED_TYPES:
         raise HTTPException(
             status_code=400,
-            detail=f"Invalid file type. Allowed: {', '.join(ALLOWED_TYPES)}",
+            detail=f"Invalid file type. Allowed: {', '.join(sorted(ALLOWED_TYPES))}",
         )
 
-    # Read file and check size
     contents = await file.read()
-    if len(contents) > MAX_FILE_SIZE:
+    if len(contents) > MAX_FILE_SIZE:  # size wasn't advertised — enforce after read
+        raise HTTPException(status_code=400, detail=too_large)
+
+    # Validate the real bytes, not the client's content-type header, with the
+    # `filetype` library. Also take the extension from the detected type so a
+    # hostile filename can't drive what we write to disk.
+    kind = filetype.guess(contents)
+    if kind is None or kind.mime not in ALLOWED_TYPES:
         raise HTTPException(
             status_code=400,
-            detail=f"File too large. Max size: {MAX_FILE_SIZE // (1024*1024)} MB",
+            detail="File content is not a valid JPEG, PNG, WebP or GIF image",
         )
 
-    # Generate unique filename
-    ext = file.filename.split(".")[-1] if "." in file.filename else "jpg"
-    filename = f"{uuid4().hex}.{ext}"
+    filename = f"{uuid4().hex}.{kind.extension}"
     filepath = os.path.join(UPLOAD_DIR, filename)
 
     # Ensure upload directory exists
@@ -237,19 +260,6 @@ async def upload_image(
         url=f"{UPLOAD_BASE_URL}/{filename}",
         filename=filename,
     )
-
-
-# ──────────────────────────────────────────────────────────────────────────────
-# Admin panel (static HTML)
-# ──────────────────────────────────────────────────────────────────────────────
-
-@router.get("/admin", include_in_schema=False)
-def admin_panel():
-    """Serve the admin panel HTML."""
-    admin_path = os.path.join(os.path.dirname(__file__), "..", "..", "static", "admin.html")
-    if not os.path.exists(admin_path):
-        raise HTTPException(status_code=404, detail="Admin panel not found")
-    return FileResponse(admin_path)
 
 
 app.include_router(router)

--- a/apps/shared/cors.py
+++ b/apps/shared/cors.py
@@ -36,8 +36,10 @@ def get_allowed_origins() -> list[str]:
         if clean_url not in origins:
             origins.append(clean_url)
 
-    # Alltid inkluder dev-origins (for lokal frontend-utvikling mot prod API)
-    origins.extend(DEV_ORIGINS)
+    # Localhost-origins kun utenfor produksjon. I prod har de ingenting å gjøre
+    # (med allow_credentials=True er en localhost-origin en unødvendig åpning).
+    if os.getenv("ENVIRONMENT", "development") != "production":
+        origins.extend(DEV_ORIGINS)
 
     # Legg til ekstra origins
     origins.extend(EXTRA_ORIGINS)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "aiofiles==25.1.0",
     "python-multipart==0.0.31",
     "alembic>=1.18.5",
+    "filetype>=1.2.0",
 ]
 
 [dependency-groups]

--- a/tests/test_projects_hardening.py
+++ b/tests/test_projects_hardening.py
@@ -1,0 +1,61 @@
+"""Hardening regression tests for the Projects app.
+
+Covers the audit fixes: security headers (#3), the /admin route-ordering fix
+(#2), CORS dev-origin gating (#4), and upload content validation (#5). All are
+DB-free — the projects app imports without a live database.
+"""
+
+import importlib
+import os
+
+from starlette.testclient import TestClient
+
+from apps.projects.main import app
+
+client = TestClient(app)
+
+
+def test_security_headers_present():  # #3
+    h = client.get("/projects/health").headers
+    assert "content-security-policy" in h
+    assert h.get("x-frame-options") == "DENY"
+    assert h.get("x-content-type-options") == "nosniff"
+
+
+def test_docs_served_locally_not_cdn():  # #3
+    body = client.get("/projects/docs").text
+    assert "/static/swagger-ui" in body
+    assert "cdn.jsdelivr" not in body
+
+
+def test_admin_route_not_shadowed_by_slug():  # #2
+    # /admin must reach the admin panel, not be captured as /{slug} (which would
+    # 404 with "Project not found").
+    r = client.get("/projects/admin")
+    assert r.status_code == 200
+    assert "Project not found" not in r.text
+
+
+def test_cors_gates_dev_origins_by_environment():  # #4
+    import apps.shared.cors as cors
+
+    os.environ["ENVIRONMENT"] = "production"
+    importlib.reload(cors)
+    prod = cors.get_allowed_origins()
+    assert not any("localhost" in o for o in prod)
+
+    os.environ["ENVIRONMENT"] = "development"
+    importlib.reload(cors)
+    assert any("localhost" in o for o in cors.get_allowed_origins())
+
+
+def test_upload_rejects_non_image_content():  # #5
+    # Bytes that aren't an image, even with an image content-type header, are
+    # rejected by the magic-byte check (filetype) before anything is written.
+    r = client.post(
+        "/projects/upload-image",
+        files={"file": ("evil.png", b"this is not an image", "image/png")},
+        headers={"X-API-Key": os.environ["INTERNAL_API_KEY"]},
+    )
+    assert r.status_code == 400
+    assert "valid" in r.json()["detail"].lower()

--- a/uv.lock
+++ b/uv.lock
@@ -78,6 +78,7 @@ dependencies = [
     { name = "alembic" },
     { name = "cryptography" },
     { name = "fastapi" },
+    { name = "filetype" },
     { name = "httpx" },
     { name = "psycopg2-binary" },
     { name = "pydantic" },
@@ -100,6 +101,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.5" },
     { name = "cryptography", specifier = "==48.0.1" },
     { name = "fastapi", specifier = ">=0.115,<1.0" },
+    { name = "filetype", specifier = ">=1.2.0" },
     { name = "httpx", specifier = ">=0.28,<0.29" },
     { name = "psycopg2-binary", specifier = "==2.9.12" },
     { name = "pydantic", specifier = ">=2.7,<3.0" },
@@ -251,6 +253,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cd/95/d3f0ae10836324a2eab98a52b61210ac609f08200bf4bb0dc8132d32f78a/fastapi-0.139.2.tar.gz", hash = "sha256:333145a6891e9b5b3cfceb69baf817e8240cde4d4588ae5a10bf56ffacb6255e", size = 423428, upload-time = "2026-07-16T15:06:17.912Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5f/c7/cb03251d9dfb177246a9809a76f189d21df32dbd4a845951881d11323b7f/fastapi-0.139.2-py3-none-any.whl", hash = "sha256:b9ad015a835173d59865e2f5d8296fbc2b317bf56a2ba1a5bfbdd03de2fd4b1c", size = 130234, upload-time = "2026-07-16T15:06:19.557Z" },
+]
+
+[[package]]
+name = "filetype"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/29/745f7d30d47fe0f251d3ad3dc2978a23141917661998763bebb6da007eb1/filetype-1.2.0.tar.gz", hash = "sha256:66b56cd6474bf41d8c54660347d37afcc3f7d1970648de365c102ef77548aadb", size = 998020, upload-time = "2022-11-02T17:34:04.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/79/1b8fa1bb3568781e84c9200f951c735f3f157429f44be0495da55894d620/filetype-1.2.0-py2.py3-none-any.whl", hash = "sha256:7ce71b6880181241cf7ac8697a2f1eb6a8bd9b429f7ad6d27b8db9ba5f1c2d25", size = 19970, upload-time = "2022-11-02T17:34:01.425Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Completes the remaining audit hardening items (previously deferred as roadmap).

| # | Fix |
|---|-----|
| **#4** | CORS: gate localhost `DEV_ORIGINS` behind `ENVIRONMENT != production` (with `allow_credentials=True`, localhost in prod was a needless opening) |
| **#3** | Projects app migrated to the shared `create_app()` factory → now gets security headers + cache-control + locally-served docs like the other services |
| **#2** | `/projects/admin` registered **before** `/projects/{slug}` so the admin panel isn't captured as a slug (was a guaranteed 404) |
| **#5** | Upload: reject on `UploadFile.size` before buffering, then validate the **real bytes** with the `filetype` library (not the spoofable content-type header); on-disk extension comes from the detected type |

## On #5 — used a library, not hand-rolled
First pass hand-rolled magic-byte sniffing; replaced it with **`filetype`** (pure-Python, maintained). It's also stricter — it rejected a malformed WebP that the hand-rolled check would have accepted.

## Verification
- `ruff` clean; **16 tests pass** (added `tests/test_projects_hardening.py`, all DB-free).
- Verified via real TestClient requests (not `.routes` introspection — starlette 1.3 nests included routes differently there): `/projects/health` 200 + headers, `/projects/admin` 200 (panel, not slug-404), `/projects/docs` served locally, upload rejects non-image bytes.

Closes the last of the audit findings; only the ruff I+UP formatting sweep (P3) remains, as a follow-up.
