### PR TITLE
chore(ruff): enable import-sort + pyupgrade

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -11,16 +11,16 @@ from logging.config import fileConfig
 
 from sqlalchemy import engine_from_config, pool
 
-from alembic import context
-
-# Shared declarative Base — every app's models attach their tables to this.
-from apps.shared.database import Base
+import apps.projects.models  # noqa: F401
 
 # Importing the model modules registers their tables on Base.metadata.
 # (n8n has no models, so it is intentionally absent.)
 import apps.strava.models  # noqa: F401
 import apps.wakatime.models  # noqa: F401
-import apps.projects.models  # noqa: F401
+from alembic import context
+
+# Shared declarative Base — every app's models attach their tables to this.
+from apps.shared.database import Base
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/alembic/versions/56883c337dbe_initial_schema.py
+++ b/alembic/versions/56883c337dbe_initial_schema.py
@@ -5,17 +5,18 @@ Revises:
 Create Date: 2026-07-24 20:06:56.781379
 
 """
-from typing import Sequence, Union
+from collections.abc import Sequence
 
-from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
+from alembic import op
+
 # revision identifiers, used by Alembic.
 revision: str = '56883c337dbe'
-down_revision: Union[str, Sequence[str], None] = None
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | Sequence[str] | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/apps/blog/main.py
+++ b/apps/blog/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, APIRouter
+from fastapi import APIRouter, FastAPI
 
 from apps.shared.cors import setup_cors
 

--- a/apps/n8n/main.py
+++ b/apps/n8n/main.py
@@ -5,6 +5,7 @@ Provides a health check endpoint that verifies n8n.vuhnger.dev is operational.
 """
 
 import logging
+
 import httpx
 from fastapi import APIRouter
 

--- a/apps/projects/main.py
+++ b/apps/projects/main.py
@@ -3,25 +3,26 @@ Projects API
 
 CRUD endpoints for portfolio projects with image upload support.
 """
-import os
 import logging
+import os
+from uuid import uuid4
+
 import aiofiles
 import filetype
-from uuid import uuid4
-from fastapi import APIRouter, Depends, HTTPException, UploadFile, File
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
 
-from apps.shared.database import get_db, check_db_connection
-from apps.shared.auth import get_api_key
-from apps.shared.app_factory import create_app
 from apps.projects.models import Project
 from apps.projects.schemas import (
-    ProjectCreate,
-    ProjectUpdate,
-    ProjectResponse,
     ImageUploadResponse,
+    ProjectCreate,
+    ProjectResponse,
+    ProjectUpdate,
 )
+from apps.shared.app_factory import create_app
+from apps.shared.auth import get_api_key
+from apps.shared.database import check_db_connection, get_db
 
 logger = logging.getLogger(__name__)
 

--- a/apps/projects/models.py
+++ b/apps/projects/models.py
@@ -3,7 +3,7 @@ Projects database models.
 
 Stores project information including metadata, images, and links.
 """
-from sqlalchemy import Column, Integer, String, Text, Boolean, DateTime, func
+from sqlalchemy import Boolean, Column, DateTime, Integer, String, Text, func
 from sqlalchemy.dialects.postgresql import JSONB
 
 from apps.shared.database import Base

--- a/apps/projects/schemas.py
+++ b/apps/projects/schemas.py
@@ -4,7 +4,7 @@ Pydantic schemas for Projects API.
 Defines request/response models with validation.
 """
 from datetime import datetime
-from typing import Optional
+
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -12,9 +12,9 @@ class ProjectBase(BaseModel):
     """Base schema with common project fields."""
     title: str = Field(..., min_length=1, max_length=200)
     slug: str = Field(..., min_length=1, max_length=100, pattern=r"^[a-z0-9-]+$")
-    description: Optional[str] = None
-    content: Optional[str] = None
-    image_url: Optional[str] = None
+    description: str | None = None
+    content: str | None = None
+    image_url: str | None = None
     technologies: list[str] = Field(default_factory=list)
     links: dict[str, str] = Field(default_factory=dict)
     featured: bool = False
@@ -29,23 +29,23 @@ class ProjectCreate(ProjectBase):
 
 class ProjectUpdate(BaseModel):
     """Schema for updating a project. All fields optional."""
-    title: Optional[str] = Field(None, min_length=1, max_length=200)
-    slug: Optional[str] = Field(None, min_length=1, max_length=100, pattern=r"^[a-z0-9-]+$")
-    description: Optional[str] = None
-    content: Optional[str] = None
-    image_url: Optional[str] = None
-    technologies: Optional[list[str]] = None
-    links: Optional[dict[str, str]] = None
-    featured: Optional[bool] = None
-    order: Optional[int] = None
-    published: Optional[bool] = None
+    title: str | None = Field(None, min_length=1, max_length=200)
+    slug: str | None = Field(None, min_length=1, max_length=100, pattern=r"^[a-z0-9-]+$")
+    description: str | None = None
+    content: str | None = None
+    image_url: str | None = None
+    technologies: list[str] | None = None
+    links: dict[str, str] | None = None
+    featured: bool | None = None
+    order: int | None = None
+    published: bool | None = None
 
 
 class ProjectResponse(ProjectBase):
     """Schema for project responses."""
     id: int
-    created_at: Optional[datetime] = None
-    updated_at: Optional[datetime] = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/apps/shared/app_factory.py
+++ b/apps/shared/app_factory.py
@@ -10,11 +10,11 @@ the security hardening can never silently drift between apps.
 """
 
 from fastapi import FastAPI
-from fastapi.staticfiles import StaticFiles
 from fastapi.openapi.docs import get_swagger_ui_oauth2_redirect_html
+from fastapi.staticfiles import StaticFiles
 
-from apps.shared.cors import setup_cors
 from apps.shared.cache_control_headers import setup_cache_control
+from apps.shared.cors import setup_cors
 from apps.shared.security_headers import setup_security_headers
 from apps.shared.swagger_ui import render_swagger_ui_html
 

--- a/apps/shared/auth.py
+++ b/apps/shared/auth.py
@@ -5,10 +5,11 @@ Simple API key-based authentication for internal services.
 Checks for X-API-Key header and validates against environment variable.
 """
 
-import os
 import hmac
 import logging
-from fastapi import Request, HTTPException, status, Security
+import os
+
+from fastapi import HTTPException, Request, Security, status
 from fastapi.security import APIKeyHeader
 from starlette.middleware.base import BaseHTTPMiddleware
 

--- a/apps/shared/cors.py
+++ b/apps/shared/cors.py
@@ -1,9 +1,9 @@
 """Sentralisert CORS-konfigurasjon for alle backend-tjenester."""
 
 import os
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-
 
 # Produksjons-origins (alltid tillatt)
 PRODUCTION_ORIGINS = [

--- a/apps/shared/database.py
+++ b/apps/shared/database.py
@@ -6,8 +6,9 @@ NO models are defined here - this is just infrastructure.
 """
 
 import os
+
 from sqlalchemy import create_engine, text
-from sqlalchemy.orm import sessionmaker, declarative_base
+from sqlalchemy.orm import declarative_base, sessionmaker
 
 # Get database URL from environment variable
 DATABASE_URL = os.getenv("DATABASE_URL")

--- a/apps/shared/encryption.py
+++ b/apps/shared/encryption.py
@@ -4,12 +4,12 @@ Token Encryption Utilities
 Provides symmetric encryption for OAuth tokens at rest using Fernet (AES-128-CBC).
 """
 
-import os
 import base64
+import os
+
 from cryptography.fernet import Fernet
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
-
 
 # Get encryption key from environment
 ENCRYPTION_KEY = os.getenv("ENCRYPTION_KEY")

--- a/apps/shared/errors.py
+++ b/apps/shared/errors.py
@@ -6,7 +6,6 @@ Provides utilities for handling errors securely without leaking sensitive inform
 
 import logging
 import uuid
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -14,7 +13,7 @@ logger = logging.getLogger(__name__)
 def log_and_sanitize_error(
     error: Exception,
     context: str,
-    user_message: Optional[str] = None
+    user_message: str | None = None
 ) -> tuple[str, str]:
     """
     Log full error details server-side and return sanitized message for client.

--- a/apps/shared/oauth_state.py
+++ b/apps/shared/oauth_state.py
@@ -4,13 +4,12 @@ OAuth State Management
 Provides secure per-request OAuth state generation and validation
 to prevent CSRF attacks in OAuth 2.0 flows.
 """
-import os
-import time
-import hmac
-import hashlib
-import secrets
 import base64
-
+import hashlib
+import hmac
+import os
+import secrets
+import time
 
 # State secret for HMAC signing (must be set in production)
 STATE_SECRET = os.getenv("STATE_SECRET")

--- a/apps/shared/upsert.py
+++ b/apps/shared/upsert.py
@@ -43,19 +43,21 @@ Usage:
     atomic_upsert_stats(db, Model, 'key', value, {'data': new_data})
 """
 
-from sqlalchemy.orm import Session
-from sqlalchemy.dialects.postgresql import insert as pg_insert
+from typing import Any
+
 from sqlalchemy import func
-from typing import Type, Any, Dict
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.orm import Session
+
 from apps.shared.database import Base
 
 
 def atomic_upsert_stats(
     db: Session,
-    model: Type[Base],
+    model: type[Base],
     unique_field: str,
     unique_value: Any,
-    update_data: Dict[str, Any],
+    update_data: dict[str, Any],
     auto_update_timestamp: bool = True,
     timestamp_field: str = 'fetched_at'
 ) -> None:
@@ -125,8 +127,8 @@ def atomic_upsert_stats(
 
 def atomic_upsert_auth(
     db: Session,
-    model: Type[Base],
-    auth_data: Dict[str, Any],
+    model: type[Base],
+    auth_data: dict[str, Any],
     auto_update_timestamp: bool = True,
     timestamp_field: str = 'updated_at'
 ) -> None:

--- a/apps/strava/client.py
+++ b/apps/strava/client.py
@@ -1,15 +1,17 @@
 """
 Strava API client wrapper using stravalib
 """
-from datetime import datetime, timedelta
 from collections import defaultdict
-from typing import Dict, List, Any
-from stravalib.client import Client
+from datetime import datetime, timedelta
+from typing import Any
+
 from sqlalchemy.orm import Session
+from stravalib.client import Client
+
 from apps.strava.utils import get_valid_token
 
 
-def get_ytd_stats(db: Session) -> Dict[str, Dict[str, Any]]:
+def get_ytd_stats(db: Session) -> dict[str, dict[str, Any]]:
     """
     Fetch year-to-date statistics from Strava.
     Returns: dict with counts, distances, times, elevation
@@ -41,7 +43,7 @@ def get_ytd_stats(db: Session) -> Dict[str, Dict[str, Any]]:
     }
 
 
-def get_recent_activities(db: Session, limit: int = 30) -> List[Dict[str, Any]]:
+def get_recent_activities(db: Session, limit: int = 30) -> list[dict[str, Any]]:
     """
     Fetch recent activities from Strava.
     Returns: list of activity dictionaries
@@ -67,7 +69,7 @@ def get_recent_activities(db: Session, limit: int = 30) -> List[Dict[str, Any]]:
     return result
 
 
-def get_monthly_stats(db: Session, months: int = 12) -> Dict[str, Dict[str, Any]]:
+def get_monthly_stats(db: Session, months: int = 12) -> dict[str, dict[str, Any]]:
     """
     Aggregate activities by month for the last N months.
     Returns: dict with monthly summaries

--- a/apps/strava/main.py
+++ b/apps/strava/main.py
@@ -5,21 +5,22 @@ OAuth integration for Strava with cached statistics.
 Single user mode - stores one set of tokens and serves cached data.
 """
 
-import os
 import logging
+import os
 from datetime import datetime
+
 from fastapi import APIRouter, Depends, HTTPException
-from fastapi.responses import RedirectResponse, FileResponse
-from sqlalchemy.orm import Session
+from fastapi.responses import FileResponse, RedirectResponse
 from sqlalchemy import desc, extract, func
+from sqlalchemy.orm import Session
 from stravalib.client import Client
 
-from apps.shared.database import get_db, check_db_connection
-from apps.shared.auth import get_api_key
 from apps.shared.app_factory import create_app
-from apps.shared.oauth_state import generate_state, validate_state
+from apps.shared.auth import get_api_key
+from apps.shared.database import check_db_connection, get_db
 from apps.shared.errors import log_and_sanitize_error
-from apps.strava.models import StravaAuth, StravaStats, StravaActivity
+from apps.shared.oauth_state import generate_state, validate_state
+from apps.strava.models import StravaActivity, StravaAuth, StravaStats
 from apps.strava.tasks import fetch_and_cache_stats
 
 logger = logging.getLogger(__name__)
@@ -122,8 +123,8 @@ def oauth_callback(code: str, state: str, db: Session = Depends(get_db)):
             athlete_id = athlete.id
 
         # Store in database (single user, id=1) using atomic upsert
-        from apps.shared.upsert import atomic_upsert_auth
         from apps.shared.encryption import encrypt_token
+        from apps.shared.upsert import atomic_upsert_auth
 
         # Encrypt tokens before storing (use database column names)
         atomic_upsert_auth(

--- a/apps/strava/models.py
+++ b/apps/strava/models.py
@@ -1,10 +1,11 @@
 """
 Strava database models for OAuth tokens and cached statistics
 """
-from sqlalchemy import Column, Integer, BigInteger, String, DateTime, JSON, func, Float
 from cryptography.fernet import InvalidToken
+from sqlalchemy import JSON, BigInteger, Column, DateTime, Float, Integer, String, func
+
 from apps.shared.database import Base
-from apps.shared.encryption import encrypt_token, decrypt_token
+from apps.shared.encryption import decrypt_token, encrypt_token
 
 
 class StravaAuth(Base):

--- a/apps/strava/tasks.py
+++ b/apps/strava/tasks.py
@@ -2,13 +2,15 @@
 Background tasks for fetching and caching Strava data
 """
 import logging
-from typing import Dict, Any, List
-from sqlalchemy.orm import Session
+from typing import Any
+
 from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.orm import Session
+
 from apps.shared.database import SessionLocal
-from apps.strava.models import StravaStats, StravaActivity
-from apps.strava.client import get_ytd_stats, get_recent_activities, get_monthly_stats, get_all_activities
 from apps.shared.upsert import atomic_upsert_stats
+from apps.strava.client import get_all_activities, get_monthly_stats, get_recent_activities, get_ytd_stats
+from apps.strava.models import StravaActivity, StravaStats
 
 logger = logging.getLogger(__name__)
 
@@ -84,7 +86,7 @@ def sync_activities(db: Session):
     logger.info(f"Total activities synced: {count}")
 
 
-def _bulk_upsert_activities(db: Session, activities: List[Dict[str, Any]]):
+def _bulk_upsert_activities(db: Session, activities: list[dict[str, Any]]):
     """
     Helper to perform bulk upsert of activities
     """
@@ -107,7 +109,7 @@ def _bulk_upsert_activities(db: Session, activities: List[Dict[str, Any]]):
     db.execute(stmt)
 
 
-def upsert_stats(db: Session, stats_type: str, data: Dict[str, Any], commit: bool = True) -> None:
+def upsert_stats(db: Session, stats_type: str, data: dict[str, Any], commit: bool = True) -> None:
     """
     Atomic insert or update of cached stats using PostgreSQL ON CONFLICT.
 

--- a/apps/strava/utils.py
+++ b/apps/strava/utils.py
@@ -3,9 +3,11 @@ Utility functions for Strava token management
 """
 import os
 import time
-from typing import Dict, Any
+from typing import Any
+
 import httpx
 from sqlalchemy.orm import Session
+
 from apps.strava.models import StravaAuth
 
 # Every outbound call needs a timeout; a hung Strava endpoint must not pin a worker.
@@ -22,7 +24,7 @@ def needs_refresh(expires_at: int, buffer_seconds: int = 3600) -> bool:
     return time.time() >= (expires_at - buffer_seconds)
 
 
-def refresh_strava_token(db: Session) -> Dict[str, Any]:
+def refresh_strava_token(db: Session) -> dict[str, Any]:
     """
     Refresh Strava access token using refresh token.
     Returns new token data or raises exception.

--- a/apps/wakatime/client.py
+++ b/apps/wakatime/client.py
@@ -3,8 +3,10 @@ WakaTime API client wrapper
 """
 import logging
 from datetime import date
+
 import httpx
 from sqlalchemy.orm import Session
+
 from apps.wakatime.utils import get_valid_token
 
 logger = logging.getLogger(__name__)

--- a/apps/wakatime/main.py
+++ b/apps/wakatime/main.py
@@ -2,22 +2,23 @@
 WakaTime Service API
 """
 
-import os
 import logging
+import os
+
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import RedirectResponse
 from sqlalchemy.orm import Session
 
-from apps.shared.database import get_db, check_db_connection
-from apps.shared.auth import get_api_key
 from apps.shared.app_factory import create_app
-from apps.shared.oauth_state import generate_state, validate_state
+from apps.shared.auth import get_api_key
+from apps.shared.database import check_db_connection, get_db
+from apps.shared.encryption import encrypt_token
 from apps.shared.errors import log_and_sanitize_error
+from apps.shared.oauth_state import generate_state, validate_state
+from apps.shared.upsert import atomic_upsert_auth
 from apps.wakatime.models import WakaTimeAuth, WakaTimeStats
 from apps.wakatime.tasks import fetch_and_cache_wakatime_stats
-from apps.shared.upsert import atomic_upsert_auth
-from apps.shared.encryption import encrypt_token
 
 logger = logging.getLogger(__name__)
 

--- a/apps/wakatime/models.py
+++ b/apps/wakatime/models.py
@@ -7,10 +7,11 @@ This module defines two tables:
 
 Follows the proven Strava integration pattern with WakaTime-specific adjustments.
 """
-from sqlalchemy import Column, Integer, String, DateTime, JSON, func
 from cryptography.fernet import InvalidToken
+from sqlalchemy import JSON, Column, DateTime, Integer, String, func
+
 from apps.shared.database import Base
-from apps.shared.encryption import encrypt_token, decrypt_token
+from apps.shared.encryption import decrypt_token, encrypt_token
 
 
 class WakaTimeAuth(Base):

--- a/apps/wakatime/tasks.py
+++ b/apps/wakatime/tasks.py
@@ -2,10 +2,11 @@
 Background tasks for fetching and caching WakaTime data
 """
 import logging
+
 from apps.shared.database import SessionLocal
-from apps.wakatime.models import WakaTimeStats, WakaTimeAuth
-from apps.wakatime.client import get_stats, get_today_summary, get_weekly_summary
 from apps.shared.upsert import atomic_upsert_stats
+from apps.wakatime.client import get_stats, get_today_summary, get_weekly_summary
+from apps.wakatime.models import WakaTimeAuth, WakaTimeStats
 
 logger = logging.getLogger(__name__)
 

--- a/apps/wakatime/utils.py
+++ b/apps/wakatime/utils.py
@@ -3,9 +3,11 @@ Utility functions for WakaTime token management
 """
 import os
 import time
-from typing import Dict, Any
+from typing import Any
+
 import httpx
 from sqlalchemy.orm import Session
+
 from apps.wakatime.models import WakaTimeAuth
 
 # Every outbound call needs a timeout; a hung WakaTime endpoint must not pin a worker.
@@ -22,7 +24,7 @@ def needs_refresh(expires_at: int, buffer_seconds: int = 300) -> bool:
     return time.time() >= (expires_at - buffer_seconds)
 
 
-def refresh_wakatime_token(db: Session) -> Dict[str, Any]:
+def refresh_wakatime_token(db: Session) -> dict[str, Any]:
     """
     Refresh WakaTime access token using refresh token.
     Returns new token data or raises exception.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,4 +57,4 @@ target-version = "py311"
 # Start enforceable and correctness-focused: pyflakes (undefined names, unused
 # imports — real breakage) + syntax errors. Style/upgrade rules can be added
 # later without blocking CI on pre-existing formatting choices.
-select = ["F", "E9"]
+select = ["F", "E9", "I", "UP"]

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -8,7 +8,6 @@ execute there.
 """
 
 import pytest
-
 from fastapi.testclient import TestClient
 
 from apps.shared.database import check_db_connection

--- a/tests/test_wakatime.py
+++ b/tests/test_wakatime.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock, patch
 
-from apps.wakatime.tasks import fetch_and_cache_wakatime_stats
 from apps.wakatime.models import WakaTimeAuth
+from apps.wakatime.tasks import fetch_and_cache_wakatime_stats
 
 
 @patch("apps.wakatime.tasks.atomic_upsert_stats")


### PR DESCRIPTION
The deferred P3 formatting sweep, run last (on a settled tree) so enabling the new rules doesn't red-flag any open PR.

## Changes
- `ruff` `select` gains **`I`** (import-sorting) and **`UP`** (pyupgrade).
- Applied the autofix repo-wide: **73 findings across 28 files** — sorted imports and modernized type hints to the py311 baseline (`Dict`/`List` → `dict`/`list`, `Optional[x]` → `x | None`, dropped now-unused `typing` imports).

## Nature
Pure formatting / type-hint modernization — **no behaviour change**.

## Verification
- `ruff check` clean; **16 tests pass**; all 4 apps import.

Closes out the audit: every P0–P3 finding is now fixed. CI going forward enforces import order + pyupgrade.
