### PR TITLE
improve: second-pass hardening (rate limit, config, logging, tests)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,3 +16,9 @@ COPY pyproject.toml uv.lock ./
 RUN uv sync --frozen
 
 COPY . .
+
+# Drop root. uid 1000 lines up with the host 'rocky' user that owns the
+# bind-mounted upload dir, so the projects app can still write uploads.
+RUN useradd -u 1000 -m appuser \
+    && chown -R appuser:appuser /app /opt/venv
+USER appuser

--- a/apps/projects/main.py
+++ b/apps/projects/main.py
@@ -12,6 +12,7 @@ from fastapi import APIRouter, Depends, HTTPException, UploadFile, File
 from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
 
+from apps.shared.config import settings
 from apps.shared.database import get_db, check_db_connection
 from apps.shared.auth import get_api_key
 from apps.shared.app_factory import create_app
@@ -29,8 +30,8 @@ logger = logging.getLogger(__name__)
 # at import time. See alembic/ and `make migrate`.
 
 # Upload configuration
-UPLOAD_DIR = os.getenv("UPLOAD_DIR", "/home/rocky/uploads/projects")
-UPLOAD_BASE_URL = os.getenv("UPLOAD_BASE_URL", "https://api.vuhnger.dev/uploads/projects")
+UPLOAD_DIR = settings.upload_dir
+UPLOAD_BASE_URL = settings.upload_base_url
 ALLOWED_TYPES = {"image/jpeg", "image/png", "image/webp", "image/gif"}
 MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB
 

--- a/apps/shared/app_factory.py
+++ b/apps/shared/app_factory.py
@@ -17,6 +17,7 @@ from apps.shared.cors import setup_cors
 from apps.shared.cache_control_headers import setup_cache_control
 from apps.shared.security_headers import setup_security_headers
 from apps.shared.rate_limit import setup_rate_limiting
+from apps.shared.logging_config import configure_logging
 from apps.shared.swagger_ui import render_swagger_ui_html
 
 
@@ -39,6 +40,7 @@ def create_app(
     Returns:
         A configured ``FastAPI`` instance. Callers add their own routers.
     """
+    configure_logging()
     prefix = url_prefix.strip("/")
 
     app = FastAPI(

--- a/apps/shared/app_factory.py
+++ b/apps/shared/app_factory.py
@@ -16,6 +16,7 @@ from fastapi.openapi.docs import get_swagger_ui_oauth2_redirect_html
 from apps.shared.cors import setup_cors
 from apps.shared.cache_control_headers import setup_cache_control
 from apps.shared.security_headers import setup_security_headers
+from apps.shared.rate_limit import setup_rate_limiting
 from apps.shared.swagger_ui import render_swagger_ui_html
 
 
@@ -55,6 +56,7 @@ def create_app(
     setup_cors(app)
     setup_cache_control(app)
     setup_security_headers(app)
+    setup_rate_limiting(app)
 
     # Serve Swagger UI assets locally (no third-party CDN) so the strict CSP applies.
     app.mount("/static", StaticFiles(directory="static"), name="static")

--- a/apps/shared/auth.py
+++ b/apps/shared/auth.py
@@ -5,12 +5,13 @@ Simple API key-based authentication for internal services.
 Checks for X-API-Key header and validates against environment variable.
 """
 
-import os
 import hmac
 import logging
 from fastapi import Request, HTTPException, status, Security
 from fastapi.security import APIKeyHeader
 from starlette.middleware.base import BaseHTTPMiddleware
+
+from apps.shared.config import settings
 
 # Setup logging
 logger = logging.getLogger(__name__)
@@ -19,8 +20,8 @@ logger = logging.getLogger(__name__)
 API_KEY_HEADER = "X-API-Key"
 
 # Get API key and environment from environment variables
-INTERNAL_API_KEY = os.getenv("INTERNAL_API_KEY")
-ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+INTERNAL_API_KEY = settings.internal_api_key
+ENVIRONMENT = settings.environment
 
 # FastAPI dependency for API key
 api_key_header = APIKeyHeader(name=API_KEY_HEADER, auto_error=False)

--- a/apps/shared/config.py
+++ b/apps/shared/config.py
@@ -1,0 +1,69 @@
+"""Centralized, typed configuration.
+
+Replaces scattered ``os.getenv`` calls with a single validated ``Settings``
+object. Fields are optional at the type level because the four apps need
+different subsets (n8n needs no DB or secrets); each module still asserts the
+specific values it requires, so the fail-fast behaviour is preserved while the
+config lives in one typed place.
+"""
+
+from functools import lru_cache
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    # Read from real environment variables only. In every deployment the process
+    # env is populated (docker compose `env_file: .env` / `environment:`), so
+    # Settings doesn't parse .env itself — which also keeps tests hermetic.
+    model_config = SettingsConfigDict(extra="ignore")
+
+    # Runtime
+    environment: str = "development"
+
+    # Database
+    database_url: str | None = None
+    db_pool_size: int = 5
+    db_max_overflow: int = 10
+    db_pool_timeout: int = 30
+    db_pool_recycle: int = 1800
+
+    # Security / auth
+    internal_api_key: str | None = None
+    state_secret: str | None = None
+    encryption_key: str | None = None
+
+    # Frontend / CORS
+    frontend_url: str | None = None
+
+    # Rate limiting
+    rate_limit_default: str = "120/minute"
+    rate_limit_storage_uri: str | None = None
+
+    # Strava OAuth
+    strava_client_id: str | None = None
+    strava_client_secret: str | None = None
+    strava_redirect_uri: str | None = None
+
+    # WakaTime OAuth
+    wakatime_client_id: str | None = None
+    wakatime_client_secret: str | None = None
+    wakatime_redirect_uri: str | None = None
+
+    # Projects uploads
+    upload_dir: str = "/home/rocky/uploads/projects"
+    upload_base_url: str = "https://api.vuhnger.dev/uploads/projects"
+
+    @property
+    def is_production(self) -> bool:
+        return self.environment == "production"
+
+
+@lru_cache
+def get_settings() -> Settings:
+    """Return the process-wide Settings singleton (cached)."""
+    return Settings()
+
+
+# Convenience singleton for module-level reads.
+settings = get_settings()

--- a/apps/shared/cors.py
+++ b/apps/shared/cors.py
@@ -1,8 +1,9 @@
 """Sentralisert CORS-konfigurasjon for alle backend-tjenester."""
 
-import os
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+
+from apps.shared.config import settings
 
 
 # Produksjons-origins (alltid tillatt)
@@ -30,7 +31,7 @@ def get_allowed_origins() -> list[str]:
     origins = list(PRODUCTION_ORIGINS)
 
     # Legg til FRONTEND_URL fra env hvis satt
-    frontend_url = os.getenv("FRONTEND_URL")
+    frontend_url = settings.frontend_url
     if frontend_url:
         clean_url = frontend_url.rstrip("/")
         if clean_url not in origins:
@@ -38,7 +39,7 @@ def get_allowed_origins() -> list[str]:
 
     # Localhost-origins kun utenfor produksjon. I prod har de ingenting å gjøre
     # (med allow_credentials=True er en localhost-origin en unødvendig åpning).
-    if os.getenv("ENVIRONMENT", "development") != "production":
+    if not settings.is_production:
         origins.extend(DEV_ORIGINS)
 
     # Legg til ekstra origins

--- a/apps/shared/database.py
+++ b/apps/shared/database.py
@@ -5,26 +5,18 @@ This module provides the basic SQLAlchemy setup for database connectivity.
 NO models are defined here - this is just infrastructure.
 """
 
-import os
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker, declarative_base
 
-# Get database URL from environment variable
-DATABASE_URL = os.getenv("DATABASE_URL")
+from apps.shared.config import settings
+
+DATABASE_URL = settings.database_url
 
 if not DATABASE_URL:
     raise RuntimeError(
         "DATABASE_URL environment variable must be set. "
         "Example: postgresql+psycopg2://user:password@host:5432/database"
     )
-
-
-def _int_env(name: str, default: int) -> int:
-    """Read a positive-int tuning knob from the environment, falling back safely."""
-    try:
-        return int(os.getenv(name, default))
-    except (TypeError, ValueError):
-        return default
 
 
 # Create engine with SQLAlchemy's default QueuePool instead of NullPool.
@@ -38,10 +30,10 @@ def _int_env(name: str, default: int) -> int:
 # All knobs are env-overridable so a low-memory host can shrink the pool.
 engine = create_engine(
     DATABASE_URL,
-    pool_size=_int_env("DB_POOL_SIZE", 5),
-    max_overflow=_int_env("DB_MAX_OVERFLOW", 10),
-    pool_timeout=_int_env("DB_POOL_TIMEOUT", 30),
-    pool_recycle=_int_env("DB_POOL_RECYCLE", 1800),
+    pool_size=settings.db_pool_size,
+    max_overflow=settings.db_max_overflow,
+    pool_timeout=settings.db_pool_timeout,
+    pool_recycle=settings.db_pool_recycle,
     pool_pre_ping=True,
     echo=False,  # Set to True for SQL query logging during development
 )

--- a/apps/shared/encryption.py
+++ b/apps/shared/encryption.py
@@ -4,15 +4,16 @@ Token Encryption Utilities
 Provides symmetric encryption for OAuth tokens at rest using Fernet (AES-128-CBC).
 """
 
-import os
 import base64
 from cryptography.fernet import Fernet
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 
+from apps.shared.config import settings
+
 
 # Get encryption key from environment
-ENCRYPTION_KEY = os.getenv("ENCRYPTION_KEY")
+ENCRYPTION_KEY = settings.encryption_key
 
 # Salt for key derivation (fixed salt is okay for this use case since key is secret)
 SALT = b"strava_wakatime_backend_salt_v1"

--- a/apps/shared/logging_config.py
+++ b/apps/shared/logging_config.py
@@ -1,0 +1,71 @@
+"""Structured logging via structlog.
+
+Routes the stdlib logging that the apps already use (``logging.getLogger``) through
+a structlog ProcessorFormatter, so existing ``logger.info(...)`` calls come out as
+JSON in production and human-friendly console lines in development — without
+rewriting a single log statement. Call ``configure_logging()`` once at startup;
+the app factory does this.
+"""
+
+import logging
+
+import structlog
+
+from apps.shared.config import settings
+
+# Shared processors applied to both structlog- and stdlib-originated records.
+_SHARED_PROCESSORS = [
+    structlog.contextvars.merge_contextvars,
+    structlog.stdlib.add_log_level,
+    structlog.stdlib.add_logger_name,
+    structlog.processors.TimeStamper(fmt="iso"),
+    structlog.processors.StackInfoRenderer(),
+    structlog.processors.format_exc_info,
+]
+
+_configured = False
+
+
+def configure_logging(force: bool = False) -> None:
+    """Configure structlog + stdlib logging. Idempotent (safe to call per app)."""
+    global _configured
+    if _configured and not force:
+        return
+
+    renderer = (
+        structlog.processors.JSONRenderer()
+        if settings.is_production
+        else structlog.dev.ConsoleRenderer()
+    )
+
+    formatter = structlog.stdlib.ProcessorFormatter(
+        foreign_pre_chain=_SHARED_PROCESSORS,
+        processors=[
+            structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+            renderer,
+        ],
+    )
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+
+    root = logging.getLogger()
+    root.handlers.clear()
+    root.addHandler(handler)
+    root.setLevel(logging.INFO)
+
+    structlog.configure(
+        processors=[
+            *_SHARED_PROCESSORS,
+            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+        ],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=True,
+    )
+    _configured = True
+
+
+def get_logger(name: str | None = None):
+    """Return a structlog logger. Prefer this for new code (supports kwargs)."""
+    return structlog.get_logger(name)

--- a/apps/shared/oauth_state.py
+++ b/apps/shared/oauth_state.py
@@ -4,16 +4,17 @@ OAuth State Management
 Provides secure per-request OAuth state generation and validation
 to prevent CSRF attacks in OAuth 2.0 flows.
 """
-import os
 import time
 import hmac
 import hashlib
 import secrets
 import base64
 
+from apps.shared.config import settings
+
 
 # State secret for HMAC signing (must be set in production)
-STATE_SECRET = os.getenv("STATE_SECRET")
+STATE_SECRET = settings.state_secret
 
 # State expiry time in seconds (10 minutes)
 STATE_EXPIRY = 600

--- a/apps/shared/rate_limit.py
+++ b/apps/shared/rate_limit.py
@@ -1,0 +1,46 @@
+"""Shared rate limiting (slowapi).
+
+A per-IP default limit is applied to every route via SlowAPIMiddleware, so no
+per-endpoint decorators are needed for the baseline. Stricter per-route limits
+can still be added with `@limiter.limit(...)` where an endpoint takes a
+`request: Request` argument.
+
+Storage is in-memory (per process). That's fine for this single-worker,
+low-traffic deployment; point `RATE_LIMIT_STORAGE_URI` at Redis if it ever runs
+multi-worker and the limit needs to be shared.
+"""
+
+import os
+
+from fastapi import FastAPI, Request
+from slowapi import Limiter, _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIMiddleware
+from slowapi.util import get_remote_address
+
+
+def _client_ip(request: Request) -> str:
+    """Real client IP, honouring the reverse proxy.
+
+    Behind caddy, `request.client.host` is the proxy (127.0.0.1), which would put
+    every caller in one bucket. Prefer the first hop in X-Forwarded-For.
+    """
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    return get_remote_address(request)
+
+
+def setup_rate_limiting(app: FastAPI) -> Limiter:
+    """Attach a per-IP rate limiter with a sensible default to every route."""
+    default_limit = os.getenv("RATE_LIMIT_DEFAULT", "120/minute")
+    limiter = Limiter(
+        key_func=_client_ip,
+        default_limits=[default_limit],
+        storage_uri=os.getenv("RATE_LIMIT_STORAGE_URI"),  # None -> in-memory
+        headers_enabled=True,  # emit X-RateLimit-* response headers
+    )
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+    app.add_middleware(SlowAPIMiddleware)
+    return limiter

--- a/apps/shared/rate_limit.py
+++ b/apps/shared/rate_limit.py
@@ -10,13 +10,13 @@ low-traffic deployment; point `RATE_LIMIT_STORAGE_URI` at Redis if it ever runs
 multi-worker and the limit needs to be shared.
 """
 
-import os
-
 from fastapi import FastAPI, Request
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 from slowapi.util import get_remote_address
+
+from apps.shared.config import settings
 
 
 def _client_ip(request: Request) -> str:
@@ -33,11 +33,10 @@ def _client_ip(request: Request) -> str:
 
 def setup_rate_limiting(app: FastAPI) -> Limiter:
     """Attach a per-IP rate limiter with a sensible default to every route."""
-    default_limit = os.getenv("RATE_LIMIT_DEFAULT", "120/minute")
     limiter = Limiter(
         key_func=_client_ip,
-        default_limits=[default_limit],
-        storage_uri=os.getenv("RATE_LIMIT_STORAGE_URI"),  # None -> in-memory
+        default_limits=[settings.rate_limit_default],
+        storage_uri=settings.rate_limit_storage_uri,  # None -> in-memory
         headers_enabled=True,  # emit X-RateLimit-* response headers
     )
     app.state.limiter = limiter

--- a/apps/strava/main.py
+++ b/apps/strava/main.py
@@ -7,7 +7,7 @@ Single user mode - stores one set of tokens and serves cached data.
 
 import logging
 from datetime import datetime
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from fastapi.responses import RedirectResponse, FileResponse
 from sqlalchemy.orm import Session
 from sqlalchemy import desc, extract, func
@@ -82,7 +82,12 @@ def authorize():
 
 
 @router.get("/callback")
-def oauth_callback(code: str, state: str, db: Session = Depends(get_db)):
+def oauth_callback(
+    code: str,
+    state: str,
+    background_tasks: BackgroundTasks,
+    db: Session = Depends(get_db),
+):
     """
     OAuth callback endpoint.
     Strava redirects here after user authorizes.
@@ -146,11 +151,9 @@ def oauth_callback(code: str, state: str, db: Session = Depends(get_db)):
         )
         raise HTTPException(status_code=500, detail=sanitized_msg)
 
-    # Trigger initial data fetch (async would be better, but simple sync for now)
-    try:
-        fetch_and_cache_stats()
-    except Exception as e:
-        logger.warning(f"Initial data fetch failed: {e}", exc_info=True)
+    # Fetch initial data AFTER the response is sent, so the OAuth redirect
+    # returns immediately instead of blocking on a full Strava sync.
+    background_tasks.add_task(fetch_and_cache_stats)
 
     # Redirect to frontend success page
     frontend_url = settings.frontend_url or "https://vuhnger.dev"

--- a/apps/strava/main.py
+++ b/apps/strava/main.py
@@ -5,7 +5,6 @@ OAuth integration for Strava with cached statistics.
 Single user mode - stores one set of tokens and serves cached data.
 """
 
-import os
 import logging
 from datetime import datetime
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -14,6 +13,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy import desc, extract, func
 from stravalib.client import Client
 
+from apps.shared.config import settings
 from apps.shared.database import get_db, check_db_connection
 from apps.shared.auth import get_api_key
 from apps.shared.app_factory import create_app
@@ -59,8 +59,8 @@ def authorize():
     Initiate OAuth flow by redirecting to Strava.
     User will be redirected to Strava to authorize the app.
     """
-    client_id = os.getenv("STRAVA_CLIENT_ID")
-    redirect_uri = os.getenv("STRAVA_REDIRECT_URI")
+    client_id = settings.strava_client_id
+    redirect_uri = settings.strava_redirect_uri
 
     if not client_id or not redirect_uri:
         raise HTTPException(status_code=500, detail="Strava OAuth not configured")
@@ -94,8 +94,8 @@ def oauth_callback(code: str, state: str, db: Session = Depends(get_db)):
             status_code=400, detail="Invalid or expired state parameter"
         )
 
-    client_id = os.getenv("STRAVA_CLIENT_ID")
-    client_secret = os.getenv("STRAVA_CLIENT_SECRET")
+    client_id = settings.strava_client_id
+    client_secret = settings.strava_client_secret
 
     if not client_id or not client_secret:
         raise HTTPException(status_code=500, detail="Strava OAuth not configured")
@@ -153,7 +153,7 @@ def oauth_callback(code: str, state: str, db: Session = Depends(get_db)):
         logger.warning(f"Initial data fetch failed: {e}", exc_info=True)
 
     # Redirect to frontend success page
-    frontend_url = os.getenv("FRONTEND_URL", "https://vuhnger.dev")
+    frontend_url = settings.frontend_url or "https://vuhnger.dev"
     return RedirectResponse(url=f"{frontend_url}/?strava=success")
 
 

--- a/apps/strava/main.py
+++ b/apps/strava/main.py
@@ -8,7 +8,7 @@ Single user mode - stores one set of tokens and serves cached data.
 import os
 import logging
 from datetime import datetime
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import RedirectResponse, FileResponse
 from sqlalchemy.orm import Session
 from sqlalchemy import desc, extract, func
@@ -342,14 +342,16 @@ def get_yearly_stats(db: Session = Depends(get_db)):
 
 @router.get("/activities")
 def get_all_activities_endpoint(
-    limit: int = 100,
-    offset: int = 0,
+    limit: int = Query(100, ge=1, le=200, description="Max rows to return (capped at 200)."),
+    offset: int = Query(0, ge=0),
     year: int = None,
     activity_type: str = None,
     db: Session = Depends(get_db),
 ):
     """
     Get all activities from history with pagination and filtering.
+
+    `limit` is capped at 200 so a client can't request an unbounded result set.
     """
     query = db.query(StravaActivity).order_by(desc(StravaActivity.start_date))
 

--- a/apps/strava/utils.py
+++ b/apps/strava/utils.py
@@ -1,11 +1,11 @@
 """
 Utility functions for Strava token management
 """
-import os
 import time
 from typing import Dict, Any
 import httpx
 from sqlalchemy.orm import Session
+from apps.shared.config import settings
 from apps.strava.models import StravaAuth
 
 # Every outbound call needs a timeout; a hung Strava endpoint must not pin a worker.
@@ -36,8 +36,8 @@ def refresh_strava_token(db: Session) -> Dict[str, Any]:
         raise ValueError("No Strava authentication found. Please complete OAuth flow first.")
 
     # Prepare token refresh request
-    client_id = os.getenv("STRAVA_CLIENT_ID")
-    client_secret = os.getenv("STRAVA_CLIENT_SECRET")
+    client_id = settings.strava_client_id
+    client_secret = settings.strava_client_secret
 
     if not client_id or not client_secret:
         raise ValueError("Strava credentials not configured")

--- a/apps/wakatime/main.py
+++ b/apps/wakatime/main.py
@@ -2,13 +2,13 @@
 WakaTime Service API
 """
 
-import os
 import logging
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import RedirectResponse
 from sqlalchemy.orm import Session
 
+from apps.shared.config import settings
 from apps.shared.database import get_db, check_db_connection
 from apps.shared.auth import get_api_key
 from apps.shared.app_factory import create_app
@@ -41,8 +41,8 @@ def health():
 
 @router.get("/authorize")
 def authorize():
-    client_id = os.getenv("WAKATIME_CLIENT_ID")
-    redirect_uri = os.getenv("WAKATIME_REDIRECT_URI")
+    client_id = settings.wakatime_client_id
+    redirect_uri = settings.wakatime_redirect_uri
 
     if not client_id or not redirect_uri:
         raise HTTPException(status_code=500, detail="WakaTime OAuth not configured")
@@ -66,9 +66,9 @@ def oauth_callback(code: str, state: str, db: Session = Depends(get_db)):
     if not validate_state(state):
         raise HTTPException(status_code=400, detail="Invalid state")
 
-    client_id = os.getenv("WAKATIME_CLIENT_ID")
-    client_secret = os.getenv("WAKATIME_CLIENT_SECRET")
-    redirect_uri = os.getenv("WAKATIME_REDIRECT_URI")
+    client_id = settings.wakatime_client_id
+    client_secret = settings.wakatime_client_secret
+    redirect_uri = settings.wakatime_redirect_uri
 
     token_url = "https://wakatime.com/oauth/token"
     data = {
@@ -139,7 +139,7 @@ def oauth_callback(code: str, state: str, db: Session = Depends(get_db)):
     except Exception as e:
         logger.warning(f"Initial fetch failed: {e}")
 
-    frontend_url = os.getenv("FRONTEND_URL", "https://vuhnger.dev")
+    frontend_url = settings.frontend_url or "https://vuhnger.dev"
     return RedirectResponse(url=f"{frontend_url}/?wakatime=success")
 
 

--- a/apps/wakatime/main.py
+++ b/apps/wakatime/main.py
@@ -4,7 +4,7 @@ WakaTime Service API
 
 import logging
 import httpx
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from fastapi.responses import RedirectResponse
 from sqlalchemy.orm import Session
 
@@ -62,7 +62,12 @@ def authorize():
 
 
 @router.get("/callback")
-def oauth_callback(code: str, state: str, db: Session = Depends(get_db)):
+def oauth_callback(
+    code: str,
+    state: str,
+    background_tasks: BackgroundTasks,
+    db: Session = Depends(get_db),
+):
     if not validate_state(state):
         raise HTTPException(status_code=400, detail="Invalid state")
 
@@ -133,11 +138,8 @@ def oauth_callback(code: str, state: str, db: Session = Depends(get_db)):
         sanitized_msg, _ = log_and_sanitize_error(e, "WakaTime Auth", "Auth failed")
         raise HTTPException(status_code=500, detail=sanitized_msg)
 
-    # Initial fetch
-    try:
-        fetch_and_cache_wakatime_stats()
-    except Exception as e:
-        logger.warning(f"Initial fetch failed: {e}")
+    # Fetch initial data after the response is sent, so the redirect is instant.
+    background_tasks.add_task(fetch_and_cache_wakatime_stats)
 
     frontend_url = settings.frontend_url or "https://vuhnger.dev"
     return RedirectResponse(url=f"{frontend_url}/?wakatime=success")

--- a/apps/wakatime/utils.py
+++ b/apps/wakatime/utils.py
@@ -1,11 +1,11 @@
 """
 Utility functions for WakaTime token management
 """
-import os
 import time
 from typing import Dict, Any
 import httpx
 from sqlalchemy.orm import Session
+from apps.shared.config import settings
 from apps.wakatime.models import WakaTimeAuth
 
 # Every outbound call needs a timeout; a hung WakaTime endpoint must not pin a worker.
@@ -36,9 +36,9 @@ def refresh_wakatime_token(db: Session) -> Dict[str, Any]:
         raise ValueError("No WakaTime authentication found. Please complete OAuth flow first.")
 
     # Prepare token refresh request
-    client_id = os.getenv("WAKATIME_CLIENT_ID")
-    client_secret = os.getenv("WAKATIME_CLIENT_SECRET")
-    redirect_uri = os.getenv("WAKATIME_REDIRECT_URI")
+    client_id = settings.wakatime_client_id
+    client_secret = settings.wakatime_client_secret
+    redirect_uri = settings.wakatime_redirect_uri
 
     if not client_id or not client_secret:
         raise ValueError("WakaTime credentials not configured")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,12 @@ services:
     restart: unless-stopped
     ports:
       - "127.0.0.1:5001:5001"
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:5001/strava/openapi.json', timeout=4).status==200 else 1)"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
     environment:
       # Database connection
       DATABASE_URL: postgresql+psycopg2://${POSTGRES_USER:-backend_user}:${POSTGRES_PASSWORD:-changeme}@db:5432/${POSTGRES_DB:-backend_db}
@@ -53,6 +59,12 @@ services:
     restart: unless-stopped
     ports:
       - "127.0.0.1:5004:5004"
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:5004/n8n/openapi.json', timeout=4).status==200 else 1)"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
     environment:
       INTERNAL_API_KEY: ${INTERNAL_API_KEY}
     networks:
@@ -64,6 +76,12 @@ services:
     restart: unless-stopped
     ports:
       - "127.0.0.1:5002:5002"
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:5002/wakatime/openapi.json', timeout=4).status==200 else 1)"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
     environment:
       DATABASE_URL: postgresql+psycopg2://${POSTGRES_USER:-backend_user}:${POSTGRES_PASSWORD:-changeme}@db:5432/${POSTGRES_DB:-backend_db}
       ENVIRONMENT: ${ENVIRONMENT:-development}
@@ -86,6 +104,12 @@ services:
     restart: unless-stopped
     ports:
       - "127.0.0.1:5005:5005"
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:5005/projects/openapi.json', timeout=4).status==200 else 1)"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
     volumes:
       - /home/rocky/uploads:/home/rocky/uploads
     environment:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "alembic>=1.18.5",
     "filetype>=1.2.0",
     "slowapi>=0.1.10",
+    "pydantic-settings>=2.14.2",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "filetype>=1.2.0",
     "slowapi>=0.1.10",
     "pydantic-settings>=2.14.2",
+    "structlog>=26.1.0",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "python-multipart==0.0.31",
     "alembic>=1.18.5",
     "filetype>=1.2.0",
+    "slowapi>=0.1.10",
 ]
 
 [dependency-groups]

--- a/tests/test_projects_hardening.py
+++ b/tests/test_projects_hardening.py
@@ -5,7 +5,6 @@ Covers the audit fixes: security headers (#3), the /admin route-ordering fix
 DB-free — the projects app imports without a live database.
 """
 
-import importlib
 import os
 
 from starlette.testclient import TestClient
@@ -36,16 +35,16 @@ def test_admin_route_not_shadowed_by_slug():  # #2
     assert "Project not found" not in r.text
 
 
-def test_cors_gates_dev_origins_by_environment():  # #4
+def test_cors_gates_dev_origins_by_environment(monkeypatch):  # #4
     import apps.shared.cors as cors
+    from apps.shared.config import settings
 
-    os.environ["ENVIRONMENT"] = "production"
-    importlib.reload(cors)
-    prod = cors.get_allowed_origins()
-    assert not any("localhost" in o for o in prod)
+    # get_allowed_origins() reads settings.is_production at call time, so patch
+    # the singleton (env+reload wouldn't reach the cached Settings).
+    monkeypatch.setattr(settings, "environment", "production")
+    assert not any("localhost" in o for o in cors.get_allowed_origins())
 
-    os.environ["ENVIRONMENT"] = "development"
-    importlib.reload(cors)
+    monkeypatch.setattr(settings, "environment", "development")
     assert any("localhost" in o for o in cors.get_allowed_origins())
 
 

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,44 @@
+"""Rate limiting is wired into every app via the shared factory."""
+
+import importlib
+import os
+
+from starlette.testclient import TestClient
+
+
+def test_default_limit_returns_429_when_exceeded():
+    os.environ["RATE_LIMIT_DEFAULT"] = "3/minute"
+    import apps.shared.rate_limit as rl
+
+    importlib.reload(rl)
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    rl.setup_rate_limiting(app)
+
+    @app.get("/ping")
+    def ping():
+        return {"ok": True}
+
+    client = TestClient(app)
+    codes = [client.get("/ping").status_code for _ in range(5)]
+    assert 429 in codes, codes
+    assert codes[:3] == [200, 200, 200]
+    os.environ.pop("RATE_LIMIT_DEFAULT", None)
+
+
+def test_ratelimit_headers_emitted():
+    import apps.shared.rate_limit as rl
+
+    importlib.reload(rl)
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    rl.setup_rate_limiting(app)
+
+    @app.get("/ping")
+    def ping():
+        return {"ok": True}
+
+    headers = {k.lower() for k in TestClient(app).get("/ping").headers}
+    assert "x-ratelimit-limit" in headers

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,44 +1,33 @@
 """Rate limiting is wired into every app via the shared factory."""
 
-import importlib
-import os
-
+from fastapi import FastAPI
 from starlette.testclient import TestClient
 
+from apps.shared.config import settings
+from apps.shared.rate_limit import setup_rate_limiting
 
-def test_default_limit_returns_429_when_exceeded():
-    os.environ["RATE_LIMIT_DEFAULT"] = "3/minute"
-    import apps.shared.rate_limit as rl
 
-    importlib.reload(rl)
-    from fastapi import FastAPI
-
+def _app_with_ping() -> FastAPI:
     app = FastAPI()
-    rl.setup_rate_limiting(app)
+    setup_rate_limiting(app)
 
     @app.get("/ping")
     def ping():
         return {"ok": True}
 
-    client = TestClient(app)
+    return app
+
+
+def test_default_limit_returns_429_when_exceeded(monkeypatch):
+    # setup_rate_limiting reads settings.rate_limit_default at call time; patch
+    # the singleton (the cached Settings won't pick up an env change).
+    monkeypatch.setattr(settings, "rate_limit_default", "3/minute")
+    client = TestClient(_app_with_ping())
     codes = [client.get("/ping").status_code for _ in range(5)]
-    assert 429 in codes, codes
     assert codes[:3] == [200, 200, 200]
-    os.environ.pop("RATE_LIMIT_DEFAULT", None)
+    assert 429 in codes, codes
 
 
 def test_ratelimit_headers_emitted():
-    import apps.shared.rate_limit as rl
-
-    importlib.reload(rl)
-    from fastapi import FastAPI
-
-    app = FastAPI()
-    rl.setup_rate_limiting(app)
-
-    @app.get("/ping")
-    def ping():
-        return {"ok": True}
-
-    headers = {k.lower() for k in TestClient(app).get("/ping").headers}
+    headers = {k.lower() for k in TestClient(_app_with_ping()).get("/ping").headers}
     assert "x-ratelimit-limit" in headers

--- a/tests/test_security_units.py
+++ b/tests/test_security_units.py
@@ -1,0 +1,68 @@
+"""Unit tests for the security-critical shared modules.
+
+These had no coverage despite being the most sensitive code: token encryption
+at rest and the HMAC-signed OAuth CSRF state.
+"""
+
+import apps.shared.oauth_state as st
+from apps.shared.encryption import decrypt_token, encrypt_token
+
+
+# --- encryption ------------------------------------------------------------
+
+def test_encrypt_decrypt_round_trip():
+    token = "strava-access-token-abc123"
+    ciphertext = encrypt_token(token)
+    assert ciphertext != token  # actually encrypted
+    assert decrypt_token(ciphertext) == token
+
+
+def test_encrypt_is_nondeterministic():
+    # Fernet embeds a random IV/timestamp, so the same plaintext encrypts
+    # differently each time — both still decrypt back.
+    a, b = encrypt_token("x"), encrypt_token("x")
+    assert a != b
+    assert decrypt_token(a) == decrypt_token(b) == "x"
+
+
+def test_empty_string_passthrough():
+    assert encrypt_token("") == ""
+    assert decrypt_token("") == ""
+
+
+def test_tampered_ciphertext_rejected():
+    from cryptography.fernet import InvalidToken
+    import pytest
+
+    ciphertext = encrypt_token("secret")
+    tampered = ciphertext[:-4] + ("AAAA" if ciphertext[-4:] != "AAAA" else "BBBB")
+    with pytest.raises(InvalidToken):
+        decrypt_token(tampered)
+
+
+# --- oauth_state -----------------------------------------------------------
+
+def test_state_round_trip():
+    state = st.generate_state()
+    assert isinstance(state, str) and state
+    assert st.validate_state(state) is True
+
+
+def test_garbage_state_rejected():
+    assert st.validate_state("not-a-valid-state") is False
+
+
+def test_tampered_state_rejected():
+    state = st.generate_state()
+    tampered = state[:-2] + ("aa" if state[-2:] != "aa" else "bb")
+    assert st.validate_state(tampered) is False
+
+
+def test_expired_state_rejected(monkeypatch):
+    state = st.generate_state()  # signed with the current timestamp
+    # Jump the clock past the expiry window; the signature is still valid but
+    # the state must be rejected as stale. Capture the real time.time first so
+    # the patched version doesn't call itself.
+    real_time = st.time.time
+    monkeypatch.setattr(st.time, "time", lambda: real_time() + st.STATE_EXPIRY + 10)
+    assert st.validate_state(state) is False

--- a/uv.lock
+++ b/uv.lock
@@ -83,6 +83,7 @@ dependencies = [
     { name = "psycopg2-binary" },
     { name = "pydantic" },
     { name = "python-multipart" },
+    { name = "slowapi" },
     { name = "sqlalchemy" },
     { name = "stravalib" },
     { name = "uvicorn", extra = ["standard"] },
@@ -106,6 +107,7 @@ requires-dist = [
     { name = "psycopg2-binary", specifier = "==2.9.12" },
     { name = "pydantic", specifier = ">=2.7,<3.0" },
     { name = "python-multipart", specifier = "==0.0.31" },
+    { name = "slowapi", specifier = ">=0.1.10" },
     { name = "sqlalchemy", specifier = ">=2.0.35,<2.1" },
     { name = "stravalib", specifier = ">=2.5,<3.0" },
     { name = "uvicorn", extras = ["standard"], specifier = "==0.51.0" },
@@ -237,6 +239,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/42/3b/d35750e41d803d1e516fd6d6011f065424924da7af1748cef4cc9cb3ede1/cryptography-48.0.1-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:7e234ac052af99f2700826a5c29ea99d9c1b1f80341cde62d11c8154dc8e0bd9", size = 4640793, upload-time = "2026-06-09T22:32:26.331Z" },
     { url = "https://files.pythonhosted.org/packages/ca/aa/cdb7181fe865285e87e96825aaab239400f1de0c3bfba9bd9769b79f1a92/cryptography-48.0.1-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:33842cf0888951cef5bc7ac724ab844a42044c1727b967b7f8997289a0464f92", size = 4668505, upload-time = "2026-06-09T22:31:27.534Z" },
     { url = "https://files.pythonhosted.org/packages/5d/8c/ce3823c06c2804f194f9e64f0d67fa3f4094a39f2bb1a990cd03603af8fc/cryptography-48.0.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:6184ca7b174f28d7c703f1290d4b297217c45355f77a98f67e9b7f14549ac54a", size = 3742204, upload-time = "2026-06-09T22:31:34.773Z" },
+]
+
+[[package]]
+name = "deprecated"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
 ]
 
 [[package]]
@@ -372,6 +386,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "limits"
+version = "5.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/69/826a5d1f45426c68d8f6539f8d275c0e4fcaa57f0c017ec3100986558a41/limits-5.8.0.tar.gz", hash = "sha256:c9e0d74aed837e8f6f50d1fcebcf5fd8130957287206bc3799adaee5092655da", size = 226104, upload-time = "2026-02-05T07:17:35.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/98/cb5ca20618d205a09d5bec7591fbc4130369c7e6308d9a676a28ff3ab22c/limits-5.8.0-py3-none-any.whl", hash = "sha256:ae1b008a43eb43073c3c579398bd4eb4c795de60952532dc24720ab45e1ac6b8", size = 60954, upload-time = "2026-02-05T07:17:34.425Z" },
 ]
 
 [[package]]
@@ -663,6 +691,18 @@ wheels = [
 ]
 
 [[package]]
+name = "slowapi"
+version = "0.1.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "limits" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/52/24527cf25a8b508926aff53350b0136561dfe86c7125f61526653666e1b2/slowapi-0.1.10.tar.gz", hash = "sha256:d320d5bc04d9f171a77fb16700faf3036d85b00f420f22924c8a225f95bd14f9", size = 13841, upload-time = "2026-06-13T11:59:31.571Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/8b/1d359f38706b4097d9a943bf8bd22599f537de4cbaff1e622d3e3936e164/slowapi-0.1.10-py3-none-any.whl", hash = "sha256:3acb61561dc9d687e3d3669362ff6a439de9ba44e2fed3a9c165da26b4b83e28", size = 14921, upload-time = "2026-06-13T11:59:30.485Z" },
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.51"
 source = { registry = "https://pypi.org/simple" }
@@ -844,4 +884,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/37/c3/48e2c03d2bd79bb45948841c592d24156312dd5f58cdf8f549febe652fb6/websockets-16.1.1-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b6b9dadbef0cccd9f4c4ee96b08898afa73e26803bbe0f6aeb5bb12b0074206d", size = 179190, upload-time = "2026-07-17T22:51:01.129Z" },
     { url = "https://files.pythonhosted.org/packages/2d/3f/73e511ecf2496ceac57dd4ed8388efe2bcf0769338a2dbf242c8366ae87e/websockets-16.1.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56cd5fc4f10a9ea8aa0804bddb7b42506cf9e136046f3b4c27de8fec9e2ecba5", size = 180330, upload-time = "2026-07-17T22:51:02.603Z" },
     { url = "https://files.pythonhosted.org/packages/be/4d/2d0d67834092e354d2b0498f014a41249a89556bc406cf86f3e1557bb463/websockets-16.1.1-py3-none-any.whl", hash = "sha256:6abbd3e82c731c8e531714466acd5d87b5e88ac3243465337ba71d68e23ae7e3", size = 173814, upload-time = "2026-07-17T22:51:04.184Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/a4/282c8e64300a59fc834518a54bf0afabb4ff9218b5fa76958b450459a844/wrapt-2.2.2.tar.gz", hash = "sha256:0788e321027c999bf221b667bd4a54aaefd1a36283749a860ac3eb77daed0302", size = 129068, upload-time = "2026-06-20T23:49:44.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/15/0c2d55168707465abfc41f33c0b23d792a5fa9b65c26983606940900a120/wrapt-2.2.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f1a2ff355ece6a111ca7a20dc86df6659c9205d3fcee674ca34f2a2854fd4e73", size = 80782, upload-time = "2026-06-20T23:47:44.367Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/b5/5c0b093eb48f8a062ef6267d3cb36e9bb1b88440181f6545a383c60efdf8/wrapt-2.2.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:55b9a899e6fff5444f229d30aa6e9ac92d2216d9d60f33c771b5d76a760d5f8e", size = 81678, upload-time = "2026-06-20T23:47:45.857Z" },
+    { url = "https://files.pythonhosted.org/packages/34/f3/de70937472dd3e8a4e6811192f9c6075efdffd4a2cd9b4596bf160f89668/wrapt-2.2.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a2d78c363f97d8bd718ee40432c66395685e9e98528ccaa423c3355d1715a26d", size = 159671, upload-time = "2026-06-20T23:47:47.345Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ec/40aed2330e7f02ecf74386ffcfef9ccb7108c6a430f15b6a252b663b1bed/wrapt-2.2.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d619e1eed9bd4f6ed9f24cd61971aa086fa86505289628d464bcf8a2c2e3f328", size = 160785, upload-time = "2026-06-20T23:47:48.759Z" },
+    { url = "https://files.pythonhosted.org/packages/45/04/aa5309beed5344b00220ae6b3b24055852192656194c27947bee1736306a/wrapt-2.2.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:518b0c5e323511ec56a38894802ddd5e1222626484e68efe63f201854ad788e5", size = 153699, upload-time = "2026-06-20T23:47:50.177Z" },
+    { url = "https://files.pythonhosted.org/packages/01/df/2def7e99d1fe87eea413f95f671924cdddcb08823b1ffd212748dfa6d062/wrapt-2.2.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4bccea5cdecffa9dd70e343741f0e41e0a16619313d04b72f78bb525162ebcd0", size = 159695, upload-time = "2026-06-20T23:47:51.602Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f6/a906d01a2ce12157bad2404957b3e2140da354b8a70b2fa48bbf282871c0/wrapt-2.2.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:209112cafd963710a05d199aae431d79a28bc76eb8e6d1bbbb8ad24340722cae", size = 152813, upload-time = "2026-06-20T23:47:53.03Z" },
+    { url = "https://files.pythonhosted.org/packages/02/49/bc0086292d239575b4c08f4cf8a4079fa58abbad58ec23abf84833a283ed/wrapt-2.2.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e5a5290e4bf2f332fc29ce72ffb9a2fff678aaac047e2e9f5f7165cd7792e099", size = 158809, upload-time = "2026-06-20T23:47:54.391Z" },
+    { url = "https://files.pythonhosted.org/packages/55/83/8fbd034de1f3e907edaa18786d5dd8f6932874edee0826c7cecb5cab03a1/wrapt-2.2.2-cp311-cp311-win32.whl", hash = "sha256:5499236ad1dc116012e2a5dd943f3f31af12fce452128e2bbcbd55a7d3d4d14c", size = 77414, upload-time = "2026-06-20T23:47:55.882Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/9c/23695baa331c6de4e874c3d78b8e0bed92e1d2a274e665b29858f6841672/wrapt-2.2.2-cp311-cp311-win_amd64.whl", hash = "sha256:8636809939152be6ae20a6cef0fed9fe60f411b47847d0426a826884b469e971", size = 80368, upload-time = "2026-06-20T23:47:57.237Z" },
+    { url = "https://files.pythonhosted.org/packages/08/49/40cefc342bf89b234a4490d741290fce781774b831aefb39c25471da96c9/wrapt-2.2.2-cp311-cp311-win_arm64.whl", hash = "sha256:5d0a142f7af07caeb5e5da87493162a7b8efa19ba919e550a746f7446e13fb30", size = 79489, upload-time = "2026-06-20T23:47:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d2/6317eb6d4554855bbf12d61857774af34747bf88a42c19bf306de67e2fa3/wrapt-2.2.2-py3-none-any.whl", hash = "sha256:5bad217350f19ce99ca5b5e71d406765ea86fe541628426772b657375ee1c048", size = 61460, upload-time = "2026-06-20T23:49:42.966Z" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -87,6 +87,7 @@ dependencies = [
     { name = "slowapi" },
     { name = "sqlalchemy" },
     { name = "stravalib" },
+    { name = "structlog" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -112,6 +113,7 @@ requires-dist = [
     { name = "slowapi", specifier = ">=0.1.10" },
     { name = "sqlalchemy", specifier = ">=2.0.35,<2.1" },
     { name = "stravalib", specifier = ">=2.5,<3.0" },
+    { name = "structlog", specifier = ">=26.1.0" },
     { name = "uvicorn", extras = ["standard"], specifier = "==0.51.0" },
 ]
 
@@ -764,6 +766,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e8/61/a3c43433e06dd2edfb249a99e7740802d2c64b2f8d5126a64118263cb75c/stravalib-2.5.0.tar.gz", hash = "sha256:d97a845a30c861bc65a854423b201497f0ea56ba5a763294b8d886269bbe6fe3", size = 4129391, upload-time = "2026-06-01T13:24:26.124Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/0a/9c510377cca40b6bebe915d451126db413391664db88ff50fe02a7be7709/stravalib-2.5.0-py3-none-any.whl", hash = "sha256:723422a3f06fd7f213b9b4b813f730a481fd0869b5b5e6a350f4823a1063d092", size = 128193, upload-time = "2026-06-01T13:24:24.697Z" },
+]
+
+[[package]]
+name = "structlog"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/89/b4a0bcfdf4f71a3dea31379f095929613d7e4528a0996bca6aa964cd0dca/structlog-26.1.0.tar.gz", hash = "sha256:f63a716cbd1b1291cf7661de7794b455acfa4c43c5bcf1630e6ad5ddc1adb3b7", size = 1459881, upload-time = "2026-06-06T07:33:39.348Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/18/489c97b834dfff9cf2fc2507cede4bcd4b11e67f84bc462acd1992496f86/structlog-26.1.0-py3-none-any.whl", hash = "sha256:e081a26d6c373e6d201eca24eede26d8ffab07f88f477822e679183428d3d91e", size = 73764, upload-time = "2026-06-06T07:33:38.046Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -82,6 +82,7 @@ dependencies = [
     { name = "httpx" },
     { name = "psycopg2-binary" },
     { name = "pydantic" },
+    { name = "pydantic-settings" },
     { name = "python-multipart" },
     { name = "slowapi" },
     { name = "sqlalchemy" },
@@ -106,6 +107,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28,<0.29" },
     { name = "psycopg2-binary", specifier = "==2.9.12" },
     { name = "pydantic", specifier = ">=2.7,<3.0" },
+    { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "python-multipart", specifier = "==0.0.31" },
     { name = "slowapi", specifier = ">=0.1.10" },
     { name = "sqlalchemy", specifier = ">=2.0.35,<2.1" },
@@ -554,6 +556,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
     { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
     { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Second-pass improvements from a fresh review after the audit (P0–P3) landed. Production-grade standards that were missing. One branch, one commit per concern (split into separate PRs later if preferred — GitHub PR creation was down when this was built).

## Security
- **Rate limiting** (`slowapi`): per-IP default limit (120/min, env-overridable) on every route via the shared factory, X-Forwarded-For–aware so callers aren't bucketed under the caddy proxy IP. Returns 429 + `X-RateLimit-*` headers.
- **Unbounded query capped**: `/strava/activities?limit=` is now `Query(ge=1, le=200)`.
- **Non-root container**: Dockerfile adds an unprivileged `appuser` (uid 1000, matches the host owner of the upload dir). Per-service `HEALTHCHECK` in the prod compose.

## Robustness
- **Typed, centralized config** (`pydantic-settings`): all `os.getenv` across 9 modules replaced by one validated `Settings`. Reads real env only (hermetic tests).
- **Background OAuth fetch**: both callbacks used `BackgroundTasks` so the redirect returns immediately instead of blocking on a full Strava/WakaTime sync.

## Quality
- **Tests for the security-critical modules** (`encryption`, `oauth_state`) — previously zero coverage: encrypt/decrypt round-trip + tamper, state generate/validate/expiry/tamper.
- **Structured logging** (`structlog`): existing `logging` calls now emit JSON in prod / console in dev; no log statements rewritten.

## Verification
- `ruff` clean; **26 tests pass**.
- Container verified running as `appuser` with health 200 and rate-limit 429 past the cap.
- Libraries chosen over hand-rolling per the new `check-for-libraries` habit (`filetype`, `slowapi`, `pydantic-settings`, `structlog`).

## Note on merge order
Overlaps with the ruff sweep (#75) and touches many files. Suggest merging #75 last, or rebasing whichever lands second.
