### PR TITLE
perf(strava): incremental activity sync

### DIFF
--- a/apps/strava/client.py
+++ b/apps/strava/client.py
@@ -114,16 +114,19 @@ def get_monthly_stats(db: Session, months: int = 12) -> dict[str, dict[str, Any]
     return result
 
 
-def get_all_activities(db: Session, limit: int = None):
+def get_all_activities(db: Session, limit: int = None, after=None):
     """
-    Fetch all historic activities from Strava.
-    Yields activity data dictionaries suitable for StravaActivity model.
+    Fetch historic activities from Strava.
+
+    Yields activity data dictionaries suitable for StravaActivity model. When
+    ``after`` (a datetime) is given, only activities on/after that time are
+    fetched — used for incremental syncs so we don't re-download all history.
     """
     access_token = get_valid_token(db)
     client = Client(access_token=access_token)
 
-    # Get all activities (paginated automatically by stravalib)
-    activities = client.get_activities(limit=limit)
+    # Paginated automatically by stravalib; `after` narrows to recent activities.
+    activities = client.get_activities(limit=limit, after=after)
 
     for activity in activities:
         yield {

--- a/apps/strava/main.py
+++ b/apps/strava/main.py
@@ -377,13 +377,16 @@ def get_all_activities_endpoint(
 
 
 @router.post("/refresh-data")
-def refresh_data(api_key: str = Depends(get_api_key)):
+def refresh_data(full: bool = False, api_key: str = Depends(get_api_key)):
     """
     Manually trigger data refresh from Strava.
     Protected endpoint - requires X-API-Key header.
+
+    Pass `?full=true` to force a full re-sync of all history instead of the
+    default incremental sync.
     """
     try:
-        fetch_and_cache_stats()
+        fetch_and_cache_stats(full=full)
         return {"status": "success", "message": "Data refreshed successfully"}
     except Exception as e:
         sanitized_msg, error_id = log_and_sanitize_error(

--- a/apps/strava/tasks.py
+++ b/apps/strava/tasks.py
@@ -2,8 +2,10 @@
 Background tasks for fetching and caching Strava data
 """
 import logging
+from datetime import timedelta
 from typing import Any
 
+from sqlalchemy import func
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
 
@@ -15,21 +17,25 @@ from apps.strava.models import StravaActivity, StravaStats
 logger = logging.getLogger(__name__)
 
 
-def fetch_and_cache_stats():
+def fetch_and_cache_stats(full: bool = False):
     """
     Fetch all stats from Strava and cache in database.
     This function should be called by a cron job or scheduler.
 
     All stats are committed atomically - either all succeed or all fail.
+
+    Args:
+        full: force a full re-sync of all history instead of the default
+            incremental sync (only activities newer than what's stored).
     """
     db = SessionLocal()
 
     try:
         logger.info("Fetching Strava data...")
 
-        # Sync all historic activities
-        sync_activities(db)
-        logger.info("Synced all activities to database")
+        # Sync historic activities (incremental by default)
+        sync_activities(db, full=full)
+        logger.info("Synced activities to database")
 
         # Fetch YTD stats
         ytd_data = get_ytd_stats(db)
@@ -59,12 +65,23 @@ def fetch_and_cache_stats():
         db.close()
 
 
-def sync_activities(db: Session):
+def sync_activities(db: Session, full: bool = False):
     """
-    Fetch all activities and upsert them into the database.
-    Uses efficient bulk upsert.
+    Fetch activities from Strava and upsert them into the database.
+
+    By default this is *incremental*: it only fetches activities newer than the
+    most recent one already stored (minus a one-day overlap so same-day edits are
+    picked up; the upsert dedupes). Pass ``full=True`` to re-sync all history.
     """
-    activities_gen = get_all_activities(db)
+    after = None
+    if not full:
+        latest = db.query(func.max(StravaActivity.start_date)).scalar()
+        if latest is not None:
+            # Overlap by a day so a just-edited recent activity is re-fetched.
+            after = latest - timedelta(days=1)
+            logger.info(f"Incremental sync: fetching activities after {after.isoformat()}")
+
+    activities_gen = get_all_activities(db, after=after)
     
     count = 0
     batch = []

--- a/tests/test_strava_sync.py
+++ b/tests/test_strava_sync.py
@@ -1,0 +1,32 @@
+"""Incremental Strava sync passes the right `after` cutoff."""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import apps.strava.tasks as tasks
+
+_LATEST = datetime(2026, 7, 1, tzinfo=UTC)
+
+
+@patch("apps.strava.tasks.get_all_activities", return_value=iter([]))
+def test_incremental_sync_fetches_after_latest_minus_overlap(mock_get):
+    db = MagicMock()
+    db.query.return_value.scalar.return_value = _LATEST
+    tasks.sync_activities(db, full=False)
+    assert mock_get.call_args.kwargs["after"] == _LATEST - timedelta(days=1)
+
+
+@patch("apps.strava.tasks.get_all_activities", return_value=iter([]))
+def test_full_sync_passes_no_cutoff(mock_get):
+    db = MagicMock()
+    db.query.return_value.scalar.return_value = _LATEST
+    tasks.sync_activities(db, full=True)
+    assert mock_get.call_args.kwargs["after"] is None
+
+
+@patch("apps.strava.tasks.get_all_activities", return_value=iter([]))
+def test_empty_db_does_a_full_fetch(mock_get):
+    db = MagicMock()
+    db.query.return_value.scalar.return_value = None  # nothing stored yet
+    tasks.sync_activities(db, full=False)
+    assert mock_get.call_args.kwargs["after"] is None


### PR DESCRIPTION
`sync_activities` re-downloaded **all** history (~695 activities) from Strava on every refresh. Make it incremental.

## Change
- Fetch only activities newer than the most recent stored one, minus a **1-day overlap** so a just-edited recent activity is re-fetched (the upsert dedupes).
- `client.get_all_activities(after=...)` forwards the cutoff to stravalib's `get_activities`.
- Empty table still does a full fetch (first backfill).
- Escape hatch: `fetch_and_cache_stats(full=True)` and `POST /strava/refresh-data?full=true` force a full re-sync.

## Why
Cuts Strava API calls + refresh time dramatically once the history exists, and eases rate-limit pressure on Strava's side.

## Verification
- `ruff` clean; **29 tests pass** (added `test_strava_sync.py` covering incremental / full-override / empty-DB cutoff logic).

Independent of the mypy PR (#77) — disjoint files.