### PR TITLE
feat(api): backward-compatible /v1 versioning

### DIFF
--- a/apps/n8n/main.py
+++ b/apps/n8n/main.py
@@ -9,7 +9,7 @@ import logging
 import httpx
 from fastapi import APIRouter
 
-from apps.shared.app_factory import create_app
+from apps.shared.app_factory import create_app, include_versioned
 
 logger = logging.getLogger(__name__)
 
@@ -48,4 +48,4 @@ async def health():
         }
 
 
-app.include_router(router)
+include_versioned(app, router)

--- a/apps/projects/main.py
+++ b/apps/projects/main.py
@@ -20,7 +20,7 @@ from apps.projects.schemas import (
     ProjectResponse,
     ProjectUpdate,
 )
-from apps.shared.app_factory import create_app
+from apps.shared.app_factory import create_app, include_versioned
 from apps.shared.auth import get_api_key
 from apps.shared.config import settings
 from apps.shared.database import check_db_connection, get_db
@@ -264,4 +264,4 @@ async def upload_image(
     )
 
 
-app.include_router(router)
+include_versioned(app, router)

--- a/apps/shared/app_factory.py
+++ b/apps/shared/app_factory.py
@@ -9,7 +9,7 @@ Centralizing it here means a new service is a single ``create_app()`` call and
 the security hardening can never silently drift between apps.
 """
 
-from fastapi import FastAPI
+from fastapi import APIRouter, FastAPI
 from fastapi.openapi.docs import get_swagger_ui_oauth2_redirect_html
 from fastapi.staticfiles import StaticFiles
 
@@ -79,3 +79,16 @@ def create_app(
         return get_swagger_ui_oauth2_redirect_html()
 
     return app
+
+
+def include_versioned(app: FastAPI, router: APIRouter, *, latest: str = "/v1") -> None:
+    """Mount a router at the versioned path and keep the bare path as an alias.
+
+    Backward-compatible API versioning: the router is served at ``/<latest>/…``
+    (the documented, canonical path) and also at its bare path — the latter
+    hidden from the schema so it reads as a deprecated alias. Existing clients
+    (the frontend, Strava's configured OAuth redirect) keep working unchanged
+    while new consumers can move to ``/v1``.
+    """
+    app.include_router(router, prefix=latest)
+    app.include_router(router, include_in_schema=False)

--- a/apps/strava/main.py
+++ b/apps/strava/main.py
@@ -14,7 +14,7 @@ from sqlalchemy import desc, extract, func
 from sqlalchemy.orm import Session
 from stravalib.client import Client
 
-from apps.shared.app_factory import create_app
+from apps.shared.app_factory import create_app, include_versioned
 from apps.shared.auth import get_api_key
 from apps.shared.config import settings
 from apps.shared.database import check_db_connection, get_db
@@ -395,4 +395,4 @@ def refresh_data(full: bool = False, api_key: str = Depends(get_api_key)):
         raise HTTPException(status_code=500, detail=sanitized_msg)
 
 
-app.include_router(router)
+include_versioned(app, router)

--- a/apps/wakatime/main.py
+++ b/apps/wakatime/main.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from fastapi.responses import RedirectResponse
 from sqlalchemy.orm import Session
 
-from apps.shared.app_factory import create_app
+from apps.shared.app_factory import create_app, include_versioned
 from apps.shared.auth import get_api_key
 from apps.shared.config import settings
 from apps.shared.database import check_db_connection, get_db
@@ -182,4 +182,4 @@ def get_all_time(db: Session = Depends(get_db)):
     return stats.to_dict()
 
 
-app.include_router(router)
+include_versioned(app, router)

--- a/tests/test_api_versioning.py
+++ b/tests/test_api_versioning.py
@@ -1,0 +1,19 @@
+"""Backward-compatible API versioning: /v1 is canonical, bare path is a hidden alias."""
+
+from starlette.testclient import TestClient
+
+from apps.n8n.main import app  # DB-free app is enough to exercise the routing
+
+client = TestClient(app)
+
+
+def test_v1_and_legacy_paths_both_work():
+    assert client.get("/n8n/health").status_code == 200          # legacy alias
+    assert client.get("/v1/n8n/health").status_code == 200       # canonical
+
+
+def test_openapi_documents_only_v1():
+    paths = client.get("/n8n/openapi.json").json()["paths"]
+    assert any(p.startswith("/v1/n8n") for p in paths)
+    # The bare service paths must be hidden from the schema (deprecated alias).
+    assert not any(p.startswith("/n8n/") and p != "/n8n/openapi.json" for p in paths)


### PR DESCRIPTION
API versioning that breaks **nothing**. New `include_versioned()` helper mounts each service router at **`/v1/<service>/…`** (canonical, in the schema) AND at its **bare path** (hidden alias, `include_in_schema=False`).

## Why backward-compatible
The live frontend and Strava's configured OAuth **redirect URI** call the bare paths — they keep working unchanged; new consumers adopt `/v1`. No frontend migration needed.

## Verification
- Both `/strava/health` and `/v1/strava/health` → 200.
- OpenAPI lists only the `/v1` paths (legacy hidden → also avoids duplicate operationIds).
- `ruff` clean; **31 tests pass** (added `test_api_versioning.py`).

(Was stacked on #78; rebased onto main after #78 merged.)