### PR TITLE
docs: document new config knobs, /v1 API, and incremental sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,34 @@ STRAVA_REDIRECT_URI=https://api.yourdomain.com/strava/callback
 FRONTEND_URL=https://yourdomain.com
 
 # ================================================================
+# WakaTime OAuth Configuration (optional — only for the wakatime service)
+# ================================================================
+# Get credentials from: https://wakatime.com/apps
+# WAKATIME_CLIENT_ID=<your_app_id>
+# WAKATIME_CLIENT_SECRET=<your_app_secret>
+# WAKATIME_REDIRECT_URI=https://api.yourdomain.com/wakatime/callback
+
+# ================================================================
+# Projects uploads (optional — only for the projects service)
+# ================================================================
+# Where uploaded images are written, and the public base URL they're served from.
+# UPLOAD_DIR=/home/rocky/uploads/projects
+# UPLOAD_BASE_URL=https://api.yourdomain.com/uploads/projects
+
+# ================================================================
+# Tuning knobs (optional — all have sensible defaults)
+# ================================================================
+# Per-IP rate limit applied to every route (slowapi). Format: "<count>/<period>".
+# RATE_LIMIT_DEFAULT=120/minute
+# Optional Redis URI to share the limit across workers (default: in-memory).
+# RATE_LIMIT_STORAGE_URI=redis://localhost:6379
+# SQLAlchemy connection-pool sizing (shrink on a low-memory host).
+# DB_POOL_SIZE=5
+# DB_MAX_OVERFLOW=10
+# DB_POOL_TIMEOUT=30
+# DB_POOL_RECYCLE=1800
+
+# ================================================================
 # Example Configurations
 # ================================================================
 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,15 @@ FastAPI backend for Strava activity tracking with OAuth, cached statistics, and 
 ## Features
 
 - OAuth 2.0 integration with automatic token refresh
-- Full historic activity storage for detailed aggregation
+- Full historic activity storage with **incremental sync** (only new activities are fetched)
 - Hourly cached statistics (YTD, recent activities, monthly aggregates)
 - Encrypted tokens at rest (Fernet AES-128)
 - CSRF-protected OAuth flow (128-bit HMAC)
-- Race-condition-free database operations
+- Race-condition-free database operations, connection pooling, and Alembic migrations
+- **Versioned API** (`/v1/...`) with the bare paths kept as backward-compatible aliases
+- **Per-IP rate limiting**, security headers, and non-root containers
+- Centralized typed config (`pydantic-settings`) and structured JSON logging (`structlog`)
 - CORS configured for frontend integration
-- 
 
 ## Quick Start
 
@@ -87,6 +89,10 @@ Use the output to replace:
 - `<GENERATE_KEY>` → ENCRYPTION_KEY
 
 **Important**: Each key must be unique. Never reuse keys across variables or environments.
+
+> Optional settings — WakaTime OAuth, projects uploads, and tuning knobs
+> (`RATE_LIMIT_DEFAULT`, `DB_POOL_SIZE`, …) — all have sensible defaults and are
+> documented in [`.env.example`](.env.example).
 
 ### Step 4: Production Server Setup (Skip for Local Development)
 
@@ -200,13 +206,17 @@ crontab -e
 ```
 
 **What this does**:
-- Fetches fresh data from Strava API every hour
+- Fetches fresh data from Strava API every hour (**incremental** — only activities newer than what's stored, so it stays cheap)
 - Updates cached YTD stats, recent activities, and monthly aggregates
 - Logs output to `/var/log/strava.log` for debugging
 
 **Alternative**: Manually refresh anytime:
 ```bash
 curl -X POST https://api.yourdomain.com/strava/refresh-data \
+  -H "X-API-Key: your-INTERNAL_API_KEY"
+
+# Force a full re-sync of all history (rarely needed):
+curl -X POST "https://api.yourdomain.com/strava/refresh-data?full=true" \
   -H "X-API-Key: your-INTERNAL_API_KEY"
 ```
 


### PR DESCRIPTION
Docs-only, bringing them in line with the hardening/second-pass work.

- **`.env.example`**: adds the previously-undocumented **WakaTime OAuth**, **projects upload** config, and the optional **tuning knobs** (`RATE_LIMIT_DEFAULT`, `RATE_LIMIT_STORAGE_URI`, `DB_POOL_*`) — all with sensible defaults.
- **README Features**: rate limiting, `/v1` versioning (bare paths kept as backward-compatible aliases), connection pooling + Alembic, typed config, structured logging.
- **README refresh section**: notes the sync is now **incremental**, plus the `?full=true` full-resync escape hatch.

No code changed.