### PR TITLE
ops: autoheal — restart unhealthy containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,6 +124,20 @@ services:
     networks:
       - backend
 
+  # Restarts any container Docker marks 'unhealthy' — the liveness-probe behaviour
+  # that `restart: unless-stopped` doesn't cover (a hung-but-not-exited process).
+  # Watches the per-service healthchecks defined above. Single-host alternative to
+  # a k8s liveness probe. It needs the Docker socket (read-write) to issue restarts.
+  autoheal:
+    image: willfarrell/autoheal:1.2.0
+    restart: unless-stopped
+    environment:
+      AUTOHEAL_CONTAINER_LABEL: all   # watch every container that has a healthcheck
+      AUTOHEAL_INTERVAL: "15"         # poll health every 15s
+      AUTOHEAL_START_PERIOD: "30"     # give a restarted container time before re-checking
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
 networks:
   backend:
 


### PR DESCRIPTION
The right-sized version of the 'always keep it running' goal — **without k8s**.

## Why
`restart: unless-stopped` only restarts on **crash/exit**. A process that **hangs but stays alive** (Docker marks it `unhealthy`) is never restarted. `willfarrell/autoheal` watches the per-service healthchecks and restarts anything unhealthy — the liveness-probe behaviour, on a single host, no control plane.

## Config
- `AUTOHEAL_CONTAINER_LABEL: all` → watches every container that has a healthcheck (all 4 apps + db).
- Polls every 15s; pinned to `willfarrell/autoheal:1.2.0` (verified it pulls on the server).

## Security note
It mounts the Docker socket **read-write** (required to issue restarts) — the standard autoheal trade-off. Acceptable on this single-tenant VM; if you ever want least-privilege, a docker-socket-proxy can front it.

## Verification
- `docker compose config` valid; image tag confirmed on the server.
- Deploys via the normal pipeline; I'll confirm autoheal is up + watching after merge.

Independent of #80/#81.