### PR TITLE
ci(deploy): reset to origin/main instead of git pull

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,7 +70,11 @@ jobs:
           script: |
             set -euo pipefail
             cd backend
-            git pull origin main
+            # Mirror origin exactly — a deploy target must never carry its own git
+            # state. `git pull` fails on any local commit/change on the server
+            # (e.g. a stray rebase), which would stall every deploy; reset can't.
+            git fetch origin main
+            git reset --hard origin/main
             echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
             docker compose pull
             # Apply DB migrations before starting the new code (see alembic/README


### PR DESCRIPTION
## Why
A deploy just failed with:
```
error: Pulling is not possible because you have unmerged files.
fatal: Exiting because of an unresolved conflict.
```
The server's `~/backend` had a stray local commit that left it mid-rebase (`UU README.md`). `git pull` can't complete with local divergence, so **every** deploy would have stalled until it was fixed by hand.

## Fix
A deploy target should never carry its own git state — it should mirror origin blindly:
```diff
- git pull origin main
+ git fetch origin main
+ git reset --hard origin/main
```
`reset --hard` can't be blocked by local commits/changes, so this failure class is gone for good.

## Verified
- YAML valid. (The immediate incident was already resolved on the server — repo reset to origin/main, autoheal deployed, all services healthy.)