### PR TITLE
feat(analytics): self-hosted Umami

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,6 +138,25 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
 
+  # Self-hosted, cookieless web analytics. Reuses the existing Postgres via a
+  # dedicated `umami` database (create it once: CREATE DATABASE umami;). Serves
+  # the dashboard + tracking script on :3000 — front it with caddy on a subdomain
+  # (e.g. analytics.vuhnger.dev). Ships its own healthcheck, so autoheal watches it.
+  umami:
+    image: ghcr.io/umami-software/umami:postgresql-latest
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:3000:3000"
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:-backend_user}:${POSTGRES_PASSWORD:-changeme}@db:5432/umami
+      DATABASE_TYPE: postgresql
+      APP_SECRET: ${UMAMI_APP_SECRET}
+    depends_on:
+      db:
+        condition: service_healthy
+    networks:
+      - backend
+
 networks:
   backend:
 


### PR DESCRIPTION
Adds **Umami** — cookieless, privacy-friendly, self-hosted web analytics — to the prod stack.

## Design
- Reuses the existing Postgres via a dedicated **`umami` database** (no extra DB container).
- Serves dashboard + tracking script on `127.0.0.1:3000` → front with caddy on a subdomain (e.g. `analytics.vuhnger.dev`).
- Ships its own healthcheck, so **autoheal** watches it.

## Server prerequisites (already done)
- `CREATE DATABASE umami;` in the existing Postgres.
- `UMAMI_APP_SECRET` added to the server `.env`.

## Verification
- Image tag valid (pulled on the server); `docker compose config` valid.
- Ran Umami against the DB — it connected and ran its migrations (**19 tables created**).

## Remaining (your side, after merge+deploy)
1. **Caddy**: route `analytics.vuhnger.dev → localhost:3000` + DNS.
2. **Dashboard**: log in (default `admin`/`umami`), **change the password**, add your website.
3. **Frontend**: drop in the `<script>` Umami gives you.

`.env.example` doc for `UMAMI_APP_SECRET` deferred to avoid conflicting with #80 (which also edits it).