### PR TITLE
feat(site): visit-notification beacon (ntfy, pluggable)

### DIFF
--- a/apps/shared/config.py
+++ b/apps/shared/config.py
@@ -54,9 +54,21 @@ class Settings(BaseSettings):
     upload_dir: str = "/home/rocky/uploads/projects"
     upload_base_url: str = "https://api.vuhnger.dev/uploads/projects"
 
+    # Notifications — ntfy topic URL, e.g. https://ntfy.sh/<secret-topic>.
+    # (Add telegram_/discord_ fields here as more providers are wired.)
+    ntfy_url: str | None = None
+
+    # Visit notifications
+    visit_notify_throttle_seconds: int = 3600  # at most one ping per IP per hour
+    visit_notify_exclude_ips: str = ""         # comma-separated IPs to ignore (e.g. yours)
+
     @property
     def is_production(self) -> bool:
         return self.environment == "production"
+
+    @property
+    def excluded_visit_ips(self) -> set[str]:
+        return {ip.strip() for ip in self.visit_notify_exclude_ips.split(",") if ip.strip()}
 
 
 @lru_cache

--- a/apps/shared/notifications.py
+++ b/apps/shared/notifications.py
@@ -1,0 +1,94 @@
+"""Pluggable notification sending.
+
+A ``Notifier`` sends a short message somewhere. The call sites just do
+``get_notifier().send(...)`` and never know (or care) where it goes — so adding a
+new destination later is one new class + one line in ``build_notifier``, with
+zero changes elsewhere. ``MultiNotifier`` fans out to several at once.
+
+Currently wired: ntfy. To add e.g. Telegram, write a ``TelegramNotifier`` with a
+``send`` method and append it in ``build_notifier``.
+"""
+
+import logging
+from typing import Protocol, runtime_checkable
+
+import httpx
+
+from apps.shared.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class Notifier(Protocol):
+    """Anything that can deliver a short message."""
+
+    def send(
+        self,
+        message: str,
+        *,
+        title: str | None = None,
+        tags: list[str] | None = None,
+    ) -> None: ...
+
+
+class NtfyNotifier:
+    """Push via ntfy (ntfy.sh or self-hosted). Zero-auth: POST to the topic URL."""
+
+    def __init__(self, topic_url: str, timeout: float = 5.0) -> None:
+        self._url = topic_url
+        self._timeout = timeout
+
+    def send(self, message, *, title=None, tags=None) -> None:
+        headers: dict[str, str] = {}
+        if title:
+            headers["Title"] = title
+        if tags:
+            headers["Tags"] = ",".join(tags)
+        httpx.post(
+            self._url,
+            content=message.encode("utf-8"),
+            headers=headers,
+            timeout=self._timeout,
+        )
+
+
+class MultiNotifier:
+    """Fan out to several notifiers; one failing doesn't stop the rest."""
+
+    def __init__(self, notifiers: list[Notifier]) -> None:
+        self._notifiers = notifiers
+
+    def send(self, message, *, title=None, tags=None) -> None:
+        for n in self._notifiers:
+            try:
+                n.send(message, title=title, tags=tags)
+            except Exception as e:
+                logger.warning("notifier %s failed: %s", type(n).__name__, e)
+
+
+class NullNotifier:
+    """No-op sink used when nothing is configured (dev / notifications off)."""
+
+    def send(self, message, *, title=None, tags=None) -> None:
+        logger.debug("notifications disabled; dropping: %s", title or message)
+
+
+def build_notifier() -> Notifier:
+    """Assemble the notifier from settings. Add new providers here."""
+    notifiers: list[Notifier] = []
+    if settings.ntfy_url:
+        notifiers.append(NtfyNotifier(settings.ntfy_url))
+    # Future providers, e.g.:
+    # if settings.telegram_bot_token and settings.telegram_chat_id:
+    #     notifiers.append(TelegramNotifier(...))
+
+    if not notifiers:
+        return NullNotifier()
+    if len(notifiers) == 1:
+        return notifiers[0]
+    return MultiNotifier(notifiers)
+
+
+# Process-wide singleton built once from config.
+notifier: Notifier = build_notifier()

--- a/apps/site/main.py
+++ b/apps/site/main.py
@@ -1,0 +1,117 @@
+"""Site service — a lightweight beacon the frontend pings on page load.
+
+When a *new* visitor arrives it pushes a notification via the pluggable notifier
+(ntfy today, more later). Historical analytics live in Umami; this is only the
+real-time "someone's here" ping. No DB — throttling is in-memory, which is fine
+for this single-worker deployment.
+"""
+
+import logging
+import time
+
+import httpx
+from fastapi import APIRouter, BackgroundTasks, Request
+from pydantic import BaseModel
+
+from apps.shared.app_factory import create_app, include_versioned
+from apps.shared.config import settings
+from apps.shared.notifications import notifier
+
+logger = logging.getLogger(__name__)
+
+app = create_app(
+    title="Site Service",
+    url_prefix="site",
+    description="Visitor beacon that pushes a notification on a new visit",
+)
+router = APIRouter(prefix="/site")
+
+# In-memory throttle: client IP -> epoch seconds of last notification.
+_last_notified: dict[str, float] = {}
+
+# Substrings that mark a request as a bot/crawler/monitor we don't want pinged for.
+_BOT_MARKERS = (
+    "bot", "crawl", "spider", "slurp", "bingpreview", "facebookexternalhit",
+    "headless", "monitor", "uptime", "curl", "wget", "python-httpx", "go-http",
+)
+
+
+class VisitIn(BaseModel):
+    path: str | None = None
+    referrer: str | None = None
+
+
+def _client_ip(request: Request) -> str:
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    return request.client.host if request.client else "unknown"
+
+
+def _looks_like_bot(user_agent: str) -> bool:
+    ua = user_agent.lower()
+    return not ua or any(marker in ua for marker in _BOT_MARKERS)
+
+
+def _throttle_ok(ip: str) -> bool:
+    """True if this IP hasn't been notified within the throttle window (and records it)."""
+    now = time.time()
+    window = settings.visit_notify_throttle_seconds
+    last = _last_notified.get(ip)
+    if last is not None and now - last < window:
+        return False
+    _last_notified[ip] = now
+    if len(_last_notified) > 10_000:  # opportunistic cleanup of stale entries
+        cutoff = now - window
+        for stale in [k for k, v in _last_notified.items() if v < cutoff]:
+            _last_notified.pop(stale, None)
+    return True
+
+
+def _geo(ip: str) -> str:
+    """Best-effort 'City, Country' from IP. Never raises; '' on any failure."""
+    try:
+        resp = httpx.get(
+            f"http://ip-api.com/json/{ip}",
+            params={"fields": "country,city"},
+            timeout=3.0,
+        )
+        data = resp.json()
+        return ", ".join(p for p in (data.get("city"), data.get("country")) if p)
+    except Exception:
+        return ""
+
+
+def _notify_visit(ip: str, user_agent: str, path: str | None, referrer: str | None) -> None:
+    where = _geo(ip)
+    device = "mobile" if "mobi" in user_agent.lower() else "desktop"
+    lines = [f"👤 New visit: {path or '/'}"]
+    if where:
+        lines.append(f"📍 {where}")
+    if referrer:
+        lines.append(f"↩︎ from {referrer}")
+    lines.append(f"🖥 {device}")
+    notifier.send("\n".join(lines), title="vuhnger.dev", tags=["wave"])
+
+
+@router.get("/health")
+def health():
+    return {"status": "ok", "service": "site"}
+
+
+@router.post("/visit")
+def visit(payload: VisitIn, request: Request, background_tasks: BackgroundTasks):
+    """Fire-and-forget beacon: returns 200 immediately; notification runs in the
+    background, and only for a genuine, non-throttled, non-excluded visitor."""
+    ip = _client_ip(request)
+    user_agent = request.headers.get("user-agent", "")
+    if (
+        not _looks_like_bot(user_agent)
+        and ip not in settings.excluded_visit_ips
+        and _throttle_ok(ip)
+    ):
+        background_tasks.add_task(_notify_visit, ip, user_agent, payload.path, payload.referrer)
+    return {"ok": True}
+
+
+include_versioned(app, router)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,6 +124,27 @@ services:
     networks:
       - backend
 
+  # Visitor beacon → pushes a notification on a new visit (no DB; ntfy via config).
+  site-api:
+    image: ghcr.io/vuhnger/backend:${BACKEND_TAG:-latest}
+    command: ["uvicorn", "apps.site.main:app", "--host", "0.0.0.0", "--port", "5006"]
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:5006:5006"
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:5006/site/openapi.json', timeout=4).status==200 else 1)"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    environment:
+      ENVIRONMENT: ${ENVIRONMENT:-development}
+      NTFY_URL: ${NTFY_URL}
+      VISIT_NOTIFY_THROTTLE_SECONDS: ${VISIT_NOTIFY_THROTTLE_SECONDS:-3600}
+      VISIT_NOTIFY_EXCLUDE_IPS: ${VISIT_NOTIFY_EXCLUDE_IPS:-}
+    networks:
+      - backend
+
   # Restarts any container Docker marks 'unhealthy' — the liveness-probe behaviour
   # that `restart: unless-stopped` doesn't cover (a hung-but-not-exited process).
   # Watches the per-service healthchecks defined above. Single-host alternative to

--- a/tests/test_visit_notifications.py
+++ b/tests/test_visit_notifications.py
@@ -1,0 +1,94 @@
+"""Notifier abstraction + the /site/visit beacon logic."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from starlette.testclient import TestClient
+
+import apps.shared.notifications as notif
+import apps.site.main as site
+from apps.shared.notifications import (
+    MultiNotifier,
+    NtfyNotifier,
+    NullNotifier,
+    build_notifier,
+)
+
+# --- notifier abstraction --------------------------------------------------
+
+def test_ntfy_notifier_posts_message_title_tags(monkeypatch):
+    captured = {}
+
+    def fake_post(url, *, content, headers, timeout):
+        captured.update(url=url, content=content, headers=headers)
+
+    monkeypatch.setattr(notif.httpx, "post", fake_post)
+    NtfyNotifier("https://ntfy.sh/topic").send("hello", title="T", tags=["wave", "eyes"])
+
+    assert captured["url"] == "https://ntfy.sh/topic"
+    assert captured["content"] == b"hello"
+    assert captured["headers"]["Title"] == "T"
+    assert captured["headers"]["Tags"] == "wave,eyes"
+
+
+def test_multi_notifier_fans_out_and_survives_a_failure():
+    delivered = []
+
+    class Good:
+        def send(self, m, *, title=None, tags=None):
+            delivered.append(m)
+
+    class Bad:
+        def send(self, m, *, title=None, tags=None):
+            raise RuntimeError("sink down")
+
+    MultiNotifier([Bad(), Good()]).send("x")  # Bad raising must not stop Good
+    assert delivered == ["x"]
+
+
+def test_build_notifier_picks_provider_from_config(monkeypatch):
+    monkeypatch.setattr(notif.settings, "ntfy_url", None)
+    assert isinstance(build_notifier(), NullNotifier)
+    monkeypatch.setattr(notif.settings, "ntfy_url", "https://ntfy.sh/t")
+    assert isinstance(build_notifier(), NtfyNotifier)
+
+
+# --- /site/visit beacon ----------------------------------------------------
+
+@pytest.fixture
+def notifier_mock(monkeypatch):
+    site._last_notified.clear()
+    monkeypatch.setattr(site, "_geo", lambda ip: "")  # no network
+    mock = MagicMock()
+    monkeypatch.setattr(site, "notifier", mock)
+    return mock
+
+
+def _post(ip: str, ua: str = "Mozilla/5.0"):
+    return TestClient(site.app).post(
+        "/site/visit",
+        json={"path": "/projects", "referrer": "google.com"},
+        headers={"x-forwarded-for": ip, "user-agent": ua},
+    )
+
+
+def test_real_visit_triggers_one_notification(notifier_mock):
+    assert _post("9.9.9.9").status_code == 200
+    assert notifier_mock.send.call_count == 1
+
+
+def test_bots_are_ignored(notifier_mock):
+    _post("9.9.9.8", ua="Googlebot/2.1 (+http://www.google.com/bot.html)")
+    assert notifier_mock.send.call_count == 0
+
+
+def test_repeat_visit_is_throttled(notifier_mock):
+    _post("9.9.9.7")
+    _post("9.9.9.7")  # same IP within the window
+    assert notifier_mock.send.call_count == 1
+
+
+def test_excluded_ip_is_ignored(notifier_mock, monkeypatch):
+    monkeypatch.setattr(site.settings, "visit_notify_exclude_ips", "9.9.9.6")
+    _post("9.9.9.6")
+    assert notifier_mock.send.call_count == 0


### PR DESCRIPTION
> **Stacked on #84** (umami) — both add a compose service. Base is `feat/umami-analytics`; retargets to main when #84 merges.

Real-time "someone visited" notifications, with sending **abstracted** so you can add/swap providers later.

## The abstraction (your main ask)
`apps/shared/notifications.py` — a `Notifier` protocol with `send(message, *, title, tags)`:
- **`NtfyNotifier`** (wired now), **`MultiNotifier`** (fan out to several at once), **`NullNotifier`** (no-op when unconfigured).
- Adding Telegram/Discord later = one new class + one line in `build_notifier()`. The beacon logic never changes.

## The beacon
New tiny **`site`** service, `POST /site/visit` (frontend pings it on load). It's deliberately quiet:
- **Filters bots**, honours an **exclude-IP list** (put your own IP there), **throttles to 1 ping/IP/hour**.
- Enrichment (geo best-effort, mobile/desktop) + send run in a **BackgroundTask** → beacon returns instantly.
- No DB (in-memory throttle). New `site-api` compose service on :5006.

## Config
`NTFY_URL`, `VISIT_NOTIFY_THROTTLE_SECONDS` (3600), `VISIT_NOTIFY_EXCLUDE_IPS`.

## Verification
- `ruff` + `mypy` clean; **38 tests pass** (notifier abstraction + beacon logic).
- **Real ntfy.sh round-trip** delivered title/tags/body end-to-end.

## Your side (after merge)
1. Pick a secret ntfy topic; install the ntfy app; subscribe to it.
2. Set `NTFY_URL=https://ntfy.sh/<your-topic>` + `VISIT_NOTIFY_EXCLUDE_IPS=<your ip>` in the server `.env`.
3. Frontend: `fetch('https://api.vuhnger.dev/site/visit', {method:'POST', headers:{'content-type':'application/json'}, body: JSON.stringify({path: location.pathname, referrer: document.referrer}), keepalive: true})` on load.
4. caddy: route the beacon path to :5006.