### PR TITLE
feat(site): always report traffic source in visit notification

### DIFF
--- a/apps/site/main.py
+++ b/apps/site/main.py
@@ -8,6 +8,7 @@ for this single-worker deployment.
 
 import logging
 import time
+from urllib.parse import parse_qs, urlsplit
 
 import httpx
 from fastapi import APIRouter, BackgroundTasks, Request
@@ -36,7 +37,14 @@ _BOT_MARKERS = (
 )
 
 
+# Query params that identify a traffic source. They survive where document.referrer
+# doesn't, so they're the fallback when the browser sends no referrer.
+_CAMPAIGN_PARAMS = ("utm_source", "ref", "source")
+
+
 class VisitIn(BaseModel):
+    # `path` may include the query string (e.g. "/?utm_source=linkedin") — send
+    # `location.pathname + location.search` from the frontend to get campaign data.
     path: str | None = None
     referrer: str | None = None
 
@@ -82,14 +90,49 @@ def _geo(ip: str) -> str:
         return ""
 
 
+def _campaign(path: str | None) -> str:
+    """The utm_source/ref value from the visited URL's query string, or ''."""
+    if not path or "?" not in path:
+        return ""
+    params = parse_qs(urlsplit(path).query)
+    for key in _CAMPAIGN_PARAMS:
+        values = params.get(key)
+        if values and values[0]:
+            return values[0][:60]
+    return ""
+
+
+def _source(referrer: str | None, path: str | None) -> str:
+    """Where the visitor came from — always a non-empty, human-readable string.
+
+    ``document.referrer`` is empty for direct visits, bookmarks, and any client
+    sending ``Referrer-Policy: no-referrer`` (most in-app browsers strip it), so we
+    fall back to campaign params and otherwise say "unknown" explicitly. Staying
+    silent would make "no referrer" indistinguishable from "beacon didn't send it".
+    """
+    campaign = _campaign(path)
+    if referrer:
+        host = urlsplit(referrer).netloc or referrer
+        return f"{host} · {campaign}" if campaign else host
+    if campaign:
+        return f"{campaign} (utm)"
+    return "direct / unknown"
+
+
 def _notify_visit(ip: str, user_agent: str, path: str | None, referrer: str | None) -> None:
     where = _geo(ip)
     device = "mobile" if "mobi" in user_agent.lower() else "desktop"
+    source = _source(referrer, path)
+    # Logged without the IP on purpose: geo is enough to recognise a visit later,
+    # and the raw address is personal data we have no reason to retain.
+    logger.info(
+        "visit notified: path=%s source=%s geo=%s device=%s",
+        path or "/", source, where or "?", device,
+    )
     lines = [f"👤 New visit: {path or '/'}"]
     if where:
         lines.append(f"📍 {where}")
-    if referrer:
-        lines.append(f"↩︎ from {referrer}")
+    lines.append(f"↩︎ {source}")
     lines.append(f"🖥 {device}")
     notifier.send("\n".join(lines), title="vuhnger.dev", tags=["wave"])
 

--- a/tests/test_visit_notifications.py
+++ b/tests/test_visit_notifications.py
@@ -64,10 +64,10 @@ def notifier_mock(monkeypatch):
     return mock
 
 
-def _post(ip: str, ua: str = "Mozilla/5.0"):
+def _post(ip: str, ua: str = "Mozilla/5.0", referrer: str = "google.com", path: str = "/projects"):
     return TestClient(site.app).post(
         "/site/visit",
-        json={"path": "/projects", "referrer": "google.com"},
+        json={"path": path, "referrer": referrer},
         headers={"x-forwarded-for": ip, "user-agent": ua},
     )
 
@@ -92,3 +92,25 @@ def test_excluded_ip_is_ignored(notifier_mock, monkeypatch):
     monkeypatch.setattr(site.settings, "visit_notify_exclude_ips", "9.9.9.6")
     _post("9.9.9.6")
     assert notifier_mock.send.call_count == 0
+
+
+# --- traffic source --------------------------------------------------------
+
+@pytest.mark.parametrize(
+    ("referrer", "path", "expected"),
+    [
+        ("https://news.ycombinator.com/item?id=1", "/", "news.ycombinator.com"),
+        (None, "/?utm_source=linkedin", "linkedin (utm)"),
+        (None, "/?ref=cv", "cv (utm)"),
+        ("https://t.co/x", "/?utm_source=twitter", "t.co · twitter"),
+        (None, "/projects", "direct / unknown"),  # never silent
+        ("", None, "direct / unknown"),
+    ],
+)
+def test_source_is_always_reported(referrer, path, expected):
+    assert site._source(referrer, path) == expected
+
+
+def test_notification_body_always_carries_a_source(notifier_mock):
+    _post("9.9.9.5", referrer="", path="/")  # browser sent no referrer at all
+    assert "↩︎ direct / unknown" in notifier_mock.send.call_args.args[0]


### PR DESCRIPTION
## Hvorfor

Fikk et besøk fra USA uten referrer-linje i varselet — og det var umulig å vite om nettleseren ikke sendte referrer, eller om beaconen var ødelagt. `document.referrer` er tom ved direktebesøk, bokmerker og alle klienter som sender `Referrer-Policy: no-referrer` (de fleste in-app-nettlesere). Den gamle koden hoppet bare over linja.

## Hva

- **Alltid** en kilde-linje i varselet: referrer-host → ellers `utm_source`/`ref` → ellers `direct / unknown`.
- `path` kan nå inneholde query string, så kampanjeparametre overlever der referrer strippes. Frontend bør sende `location.pathname + location.search`.
- Strukturert logg per varslet besøk (geo, **ikke** IP — rå IP er persondata vi ikke har grunn til å lagre).

## Test

6 nye parametriserte kilde-caser + assert på at varselteksten aldri er taus om kilde. `14 passed`.