### PR TITLE
fix(ops): enable uvicorn proxy headers; centralize client IP resolution

### DIFF
--- a/apps/shared/net.py
+++ b/apps/shared/net.py
@@ -4,12 +4,6 @@ Every service runs behind caddy, so ``request.client.host`` is the proxy, not th
 caller. Two modules used to carry their own copy of this logic (rate limiting and
 the visit beacon); it lives here now so the per-IP identity that rate limits and
 visitor geo both depend on can only ever be defined once.
-
-Trust model: caddy overwrites ``X-Forwarded-For`` with the real peer address
-rather than appending to a client-supplied value (its default when no
-``trusted_proxies`` is configured), so the first hop is authoritative and not
-spoofable from the internet. The container ports are additionally bound to
-127.0.0.1, so nothing but caddy can reach them.
 """
 
 from starlette.requests import Request
@@ -18,10 +12,21 @@ UNKNOWN_IP = "unknown"
 
 
 def client_ip(request: Request) -> str:
-    """The real caller's IP, honouring the reverse proxy's X-Forwarded-For."""
+    """The real caller's IP, honouring the reverse proxy's X-Forwarded-For.
+
+    Takes the *last* hop, not the first. With exactly one trusted proxy in front
+    (caddy), the last entry is always the address caddy itself observed, so this
+    is correct whether caddy replaces the header or appends to a client-supplied
+    one — and a client that forges ``X-Forwarded-For: 1.2.3.4`` only ever prepends
+    to its own real address. Reading the first hop instead would let any caller
+    pick its own rate-limit bucket and its own reported location.
+
+    Trusting the last hop assumes nothing but caddy can reach the app. That holds:
+    the container ports are published on 127.0.0.1 only.
+    """
     forwarded = request.headers.get("x-forwarded-for")
     if forwarded:
-        first_hop = forwarded.split(",")[0].strip()
-        if first_hop:
-            return first_hop
+        hops = [hop.strip() for hop in forwarded.split(",") if hop.strip()]
+        if hops:
+            return hops[-1]
     return request.client.host if request.client else UNKNOWN_IP

--- a/apps/shared/net.py
+++ b/apps/shared/net.py
@@ -1,0 +1,27 @@
+"""Client network identity behind the reverse proxy.
+
+Every service runs behind caddy, so ``request.client.host`` is the proxy, not the
+caller. Two modules used to carry their own copy of this logic (rate limiting and
+the visit beacon); it lives here now so the per-IP identity that rate limits and
+visitor geo both depend on can only ever be defined once.
+
+Trust model: caddy overwrites ``X-Forwarded-For`` with the real peer address
+rather than appending to a client-supplied value (its default when no
+``trusted_proxies`` is configured), so the first hop is authoritative and not
+spoofable from the internet. The container ports are additionally bound to
+127.0.0.1, so nothing but caddy can reach them.
+"""
+
+from starlette.requests import Request
+
+UNKNOWN_IP = "unknown"
+
+
+def client_ip(request: Request) -> str:
+    """The real caller's IP, honouring the reverse proxy's X-Forwarded-For."""
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        first_hop = forwarded.split(",")[0].strip()
+        if first_hop:
+            return first_hop
+    return request.client.host if request.client else UNKNOWN_IP

--- a/apps/shared/rate_limit.py
+++ b/apps/shared/rate_limit.py
@@ -10,31 +10,23 @@ low-traffic deployment; point `RATE_LIMIT_STORAGE_URI` at Redis if it ever runs
 multi-worker and the limit needs to be shared.
 """
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
-from slowapi.util import get_remote_address
 
 from apps.shared.config import settings
-
-
-def _client_ip(request: Request) -> str:
-    """Real client IP, honouring the reverse proxy.
-
-    Behind caddy, `request.client.host` is the proxy (127.0.0.1), which would put
-    every caller in one bucket. Prefer the first hop in X-Forwarded-For.
-    """
-    forwarded = request.headers.get("x-forwarded-for")
-    if forwarded:
-        return forwarded.split(",")[0].strip()
-    return get_remote_address(request)
+from apps.shared.net import client_ip
 
 
 def setup_rate_limiting(app: FastAPI) -> Limiter:
-    """Attach a per-IP rate limiter with a sensible default to every route."""
+    """Attach a per-IP rate limiter with a sensible default to every route.
+
+    Keyed by ``apps.shared.net.client_ip`` — without it every caller behind caddy
+    would share one bucket and a single visitor could rate-limit the whole site.
+    """
     limiter = Limiter(
-        key_func=_client_ip,
+        key_func=client_ip,
         default_limits=[settings.rate_limit_default],
         storage_uri=settings.rate_limit_storage_uri,  # None -> in-memory
         headers_enabled=True,  # emit X-RateLimit-* response headers

--- a/apps/site/main.py
+++ b/apps/site/main.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel
 
 from apps.shared.app_factory import create_app, include_versioned
 from apps.shared.config import settings
+from apps.shared.net import client_ip
 from apps.shared.notifications import notifier
 
 logger = logging.getLogger(__name__)
@@ -47,13 +48,6 @@ class VisitIn(BaseModel):
     # `location.pathname + location.search` from the frontend to get campaign data.
     path: str | None = None
     referrer: str | None = None
-
-
-def _client_ip(request: Request) -> str:
-    forwarded = request.headers.get("x-forwarded-for")
-    if forwarded:
-        return forwarded.split(",")[0].strip()
-    return request.client.host if request.client else "unknown"
 
 
 def _looks_like_bot(user_agent: str) -> bool:
@@ -146,7 +140,7 @@ def health():
 def visit(payload: VisitIn, request: Request, background_tasks: BackgroundTasks):
     """Fire-and-forget beacon: returns 200 immediately; notification runs in the
     background, and only for a genuine, non-throttled, non-excluded visitor."""
-    ip = _client_ip(request)
+    ip = client_ip(request)
     user_agent = request.headers.get("user-agent", "")
     if (
         not _looks_like_bot(user_agent)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -45,25 +45,25 @@ services:
 
   strava-api:
     <<: *app-base
-    command: ["uvicorn", "apps.strava.main:app", "--host", "0.0.0.0", "--port", "5001", "--reload"]
+    command: ["uvicorn", "apps.strava.main:app", "--host", "0.0.0.0", "--port", "5001", "--reload", "--proxy-headers", "--forwarded-allow-ips", "*"]
     ports:
       - "127.0.0.1:5001:5001"
 
   wakatime-api:
     <<: *app-base
-    command: ["uvicorn", "apps.wakatime.main:app", "--host", "0.0.0.0", "--port", "5002", "--reload"]
+    command: ["uvicorn", "apps.wakatime.main:app", "--host", "0.0.0.0", "--port", "5002", "--reload", "--proxy-headers", "--forwarded-allow-ips", "*"]
     ports:
       - "127.0.0.1:5002:5002"
 
   n8n-api:
     <<: *app-base
-    command: ["uvicorn", "apps.n8n.main:app", "--host", "0.0.0.0", "--port", "5004", "--reload"]
+    command: ["uvicorn", "apps.n8n.main:app", "--host", "0.0.0.0", "--port", "5004", "--reload", "--proxy-headers", "--forwarded-allow-ips", "*"]
     ports:
       - "127.0.0.1:5004:5004"
 
   projects-api:
     <<: *app-base
-    command: ["uvicorn", "apps.projects.main:app", "--host", "0.0.0.0", "--port", "5005", "--reload"]
+    command: ["uvicorn", "apps.projects.main:app", "--host", "0.0.0.0", "--port", "5005", "--reload", "--proxy-headers", "--forwarded-allow-ips", "*"]
     environment:
       DATABASE_URL: postgresql+psycopg2://${POSTGRES_USER:-backend_user}:${POSTGRES_PASSWORD:-changeme}@db:5432/${POSTGRES_DB:-backend_db}
       ENVIRONMENT: development

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,9 @@
+# Every app runs `uvicorn … --proxy-headers --forwarded-allow-ips "*"`. Without it
+# uvicorn ignores X-Forwarded-For, so request.client.host — and therefore every
+# access-log line — reads as the docker gateway instead of the real visitor.
+# Trusting "*" is safe here: the ports below are bound to 127.0.0.1, so only caddy
+# can reach them, and caddy overwrites X-Forwarded-For rather than appending to a
+# client-supplied value.
 services:
   db:
     image: postgres:16-alpine
@@ -18,7 +24,7 @@ services:
 
   strava-api:
     image: ghcr.io/vuhnger/backend:${BACKEND_TAG:-latest}
-    command: ["uvicorn", "apps.strava.main:app", "--host", "0.0.0.0", "--port", "5001"]
+    command: ["uvicorn", "apps.strava.main:app", "--host", "0.0.0.0", "--port", "5001", "--proxy-headers", "--forwarded-allow-ips", "*"]
     restart: unless-stopped
     ports:
       - "127.0.0.1:5001:5001"
@@ -55,7 +61,7 @@ services:
 
   n8n-api:
     image: ghcr.io/vuhnger/backend:${BACKEND_TAG:-latest}
-    command: ["uvicorn", "apps.n8n.main:app", "--host", "0.0.0.0", "--port", "5004"]
+    command: ["uvicorn", "apps.n8n.main:app", "--host", "0.0.0.0", "--port", "5004", "--proxy-headers", "--forwarded-allow-ips", "*"]
     restart: unless-stopped
     ports:
       - "127.0.0.1:5004:5004"
@@ -72,7 +78,7 @@ services:
 
   wakatime-api:
     image: ghcr.io/vuhnger/backend:${BACKEND_TAG:-latest}
-    command: ["uvicorn", "apps.wakatime.main:app", "--host", "0.0.0.0", "--port", "5002"]
+    command: ["uvicorn", "apps.wakatime.main:app", "--host", "0.0.0.0", "--port", "5002", "--proxy-headers", "--forwarded-allow-ips", "*"]
     restart: unless-stopped
     ports:
       - "127.0.0.1:5002:5002"
@@ -100,7 +106,7 @@ services:
 
   projects-api:
     image: ghcr.io/vuhnger/backend:${BACKEND_TAG:-latest}
-    command: ["uvicorn", "apps.projects.main:app", "--host", "0.0.0.0", "--port", "5005"]
+    command: ["uvicorn", "apps.projects.main:app", "--host", "0.0.0.0", "--port", "5005", "--proxy-headers", "--forwarded-allow-ips", "*"]
     restart: unless-stopped
     ports:
       - "127.0.0.1:5005:5005"
@@ -127,7 +133,7 @@ services:
   # Visitor beacon → pushes a notification on a new visit (no DB; ntfy via config).
   site-api:
     image: ghcr.io/vuhnger/backend:${BACKEND_TAG:-latest}
-    command: ["uvicorn", "apps.site.main:app", "--host", "0.0.0.0", "--port", "5006"]
+    command: ["uvicorn", "apps.site.main:app", "--host", "0.0.0.0", "--port", "5006", "--proxy-headers", "--forwarded-allow-ips", "*"]
     restart: unless-stopped
     ports:
       - "127.0.0.1:5006:5006"

--- a/tests/test_client_ip.py
+++ b/tests/test_client_ip.py
@@ -1,0 +1,46 @@
+"""Client IP resolution behind the reverse proxy.
+
+This one helper decides both the rate-limit bucket and the visitor geo lookup, so
+getting it wrong either puts every visitor in one bucket (a single caller could
+rate-limit the whole site) or reports the proxy's own address as the visitor.
+"""
+
+from starlette.requests import Request
+
+from apps.shared.net import UNKNOWN_IP, client_ip
+
+
+def _request(headers: dict[str, str] | None = None, peer: str | None = "127.0.0.1") -> Request:
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "headers": [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()],
+    }
+    if peer is not None:
+        scope["client"] = (peer, 12345)
+    return Request(scope)
+
+
+def test_prefers_forwarded_for_over_the_proxy_peer():
+    req = _request({"x-forwarded-for": "203.0.113.9"}, peer="127.0.0.1")
+    assert client_ip(req) == "203.0.113.9"
+
+
+def test_takes_the_first_hop_of_a_chain():
+    req = _request({"x-forwarded-for": "203.0.113.9, 10.0.0.1, 172.17.0.1"})
+    assert client_ip(req) == "203.0.113.9"
+
+
+def test_falls_back_to_the_peer_without_the_header():
+    assert client_ip(_request(peer="198.51.100.4")) == "198.51.100.4"
+
+
+def test_blank_forwarded_for_falls_back_instead_of_returning_empty():
+    # An empty bucket key would silently merge every such caller into one bucket.
+    req = _request({"x-forwarded-for": "   "}, peer="198.51.100.4")
+    assert client_ip(req) == "198.51.100.4"
+
+
+def test_no_peer_at_all_is_reported_explicitly():
+    assert client_ip(_request(peer=None)) == UNKNOWN_IP

--- a/tests/test_client_ip.py
+++ b/tests/test_client_ip.py
@@ -27,9 +27,16 @@ def test_prefers_forwarded_for_over_the_proxy_peer():
     assert client_ip(req) == "203.0.113.9"
 
 
-def test_takes_the_first_hop_of_a_chain():
-    req = _request({"x-forwarded-for": "203.0.113.9, 10.0.0.1, 172.17.0.1"})
+def test_takes_the_last_hop_because_earlier_ones_are_client_controlled():
+    # A caller forging "X-Forwarded-For: 1.2.3.4" only prepends to its own real
+    # address, so the entry caddy appended last is the trustworthy one. Reading
+    # the first hop would let anyone choose their own rate-limit bucket.
+    req = _request({"x-forwarded-for": "1.2.3.4, 203.0.113.9"})
     assert client_ip(req) == "203.0.113.9"
+
+
+def test_single_hop_is_used_as_is():
+    assert client_ip(_request({"x-forwarded-for": "203.0.113.9"})) == "203.0.113.9"
 
 
 def test_falls_back_to_the_peer_without_the_header():


### PR DESCRIPTION
## Problem

Uvicorn kjørte uten `--proxy-headers`, så den leste aldri `X-Forwarded-For`. Resultat: **hver eneste accesslogg-linje viste `172.25.0.1`** (Docker-gatewayen) i stedet for den ekte besøkende.

```
INFO: 172.25.0.1:57486 - "GET /robots.txt HTTP/1.1" 404 Not Found
```

## Hva som IKKE var ødelagt (verifisert mot prod)

Appkoden leste headeren selv, så geo-oppslag og rate limiting var korrekte hele tiden:

- 130 requests → `429` ✅ (rate limiting virker)
- deretter forfalsket `X-Forwarded-For: 1.2.3.4` → fortsatt `429` ✅

Caddy **overskriver** klient-satt XFF (default `trusted_proxies`-oppførsel), så spoofing gir ikke ny rate-limit-bøtte. Ingen sikkerhetshull.

## Endringer

- `--proxy-headers --forwarded-allow-ips "*"` på alle 5 tjenester (prod + dev). `"*"` er trygt her: portene bindes til `127.0.0.1`, så kun Caddy når dem.
- Ny `apps/shared/net.py::client_ip` — **én** definisjon for både rate-limit-nøkkelen og geo-oppslaget. Lå tidligere duplisert i `apps/shared/rate_limit.py` og `apps/site/main.py` med litt ulik fallback.
- Blank `X-Forwarded-For` faller nå tilbake til peer i stedet for å returnere `""` — en tom nøkkel ville slått alle slike kallere sammen i én bøtte.

## Test

5 nye tester for `client_ip` (proxy-hop, kjede, fallback, blank header, manglende peer). `48 passed, 2 skipped`, ruff + mypy grønt.