### PR TITLE
fix(security): enforce rate limiting on router-included routes

### DIFF
--- a/apps/shared/rate_limit.py
+++ b/apps/shared/rate_limit.py
@@ -1,38 +1,71 @@
-"""Shared rate limiting (slowapi).
+"""Shared per-IP rate limiting.
 
-A per-IP default limit is applied to every route via SlowAPIMiddleware, so no
-per-endpoint decorators are needed for the baseline. Stricter per-route limits
-can still be added with `@limiter.limit(...)` where an endpoint takes a
-`request: Request` argument.
+A single default limit is applied to every request, keyed on the real client IP
+(``apps.shared.net.client_ip``) so callers behind the proxy don't share a bucket.
 
-Storage is in-memory (per process). That's fine for this single-worker,
-low-traffic deployment; point `RATE_LIMIT_STORAGE_URI` at Redis if it ever runs
-multi-worker and the limit needs to be shared.
+This is deliberately built straight on ``limits`` rather than on slowapi. slowapi
+enforces limits by looking up the matched route's ``.endpoint`` attribute, and
+FastAPI wraps ``include_router()`` routes in an object that has no ``.endpoint``
+— so every router-mounted path (i.e. every real endpoint in this repo) was
+silently exempt while only the three factory-registered routes were limited. A
+limiter that keys off the request alone cannot regress that way.
+
+Storage is in-memory per process, which is right for this single-worker
+deployment; point ``RATE_LIMIT_STORAGE_URI`` at Redis to share it across workers.
 """
 
-from fastapi import FastAPI
-from slowapi import Limiter, _rate_limit_exceeded_handler
-from slowapi.errors import RateLimitExceeded
-from slowapi.middleware import SlowAPIMiddleware
+import math
+import time
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse, Response
+from limits import parse
+from limits.storage import storage_from_string
+from limits.strategies import MovingWindowRateLimiter
 
 from apps.shared.config import settings
 from apps.shared.net import client_ip
 
+# Paths exempt from limiting: the container healthchecks poll these every 15-30s
+# and must never be throttled into a false 'unhealthy' verdict (which autoheal
+# would answer by restarting a perfectly good container).
+EXEMPT_SUFFIXES = ("/health", "/openapi.json")
 
-def setup_rate_limiting(app: FastAPI) -> Limiter:
-    """Attach a per-IP rate limiter with a sensible default to every route.
 
-    Keyed by ``apps.shared.net.client_ip`` — without it every caller behind caddy
-    would share one bucket and a single visitor could rate-limit the whole site.
-    """
-    limiter = Limiter(
-        key_func=client_ip,
-        default_limits=[settings.rate_limit_default],
-        storage_uri=settings.rate_limit_storage_uri,  # None -> in-memory
-        headers_enabled=True,  # emit X-RateLimit-* response headers
+def _is_exempt(path: str) -> bool:
+    return path.endswith(EXEMPT_SUFFIXES)
+
+
+def setup_rate_limiting(app: FastAPI) -> None:
+    """Apply a per-IP default limit to every request the app serves."""
+    item = parse(settings.rate_limit_default)
+    limiter = MovingWindowRateLimiter(
+        storage_from_string(settings.rate_limit_storage_uri or "memory://")
     )
-    app.state.limiter = limiter
-    # slowapi's handler signature is narrower than Starlette's generic type.
-    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)  # type: ignore[arg-type]
-    app.add_middleware(SlowAPIMiddleware)
-    return limiter
+
+    @app.middleware("http")
+    async def enforce_rate_limit(request: Request, call_next) -> Response:
+        if _is_exempt(request.url.path):
+            return await call_next(request)
+
+        key = client_ip(request)
+        if not limiter.hit(item, key):
+            reset_at, _ = limiter.get_window_stats(item, key)
+            retry_after = max(1, math.ceil(reset_at - time.time()))
+            return JSONResponse(
+                {"detail": "Rate limit exceeded"},
+                status_code=429,
+                headers={
+                    "Retry-After": str(retry_after),
+                    "X-RateLimit-Limit": str(item.amount),
+                    "X-RateLimit-Remaining": "0",
+                    "X-RateLimit-Reset": str(int(reset_at)),
+                },
+            )
+
+        response = await call_next(request)
+        reset_at, remaining = limiter.get_window_stats(item, key)
+        response.headers["X-RateLimit-Limit"] = str(item.amount)
+        response.headers["X-RateLimit-Remaining"] = str(remaining)
+        response.headers["X-RateLimit-Reset"] = str(int(reset_at))
+        return response

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,10 @@ requires-python = ">=3.11,<3.12"
 dependencies = [
     # FastAPI and web server. Pydantic 2 + a Starlette new enough for httpx 0.28
     # (which dropped the TestClient `app=` shortcut).
-    "fastapi>=0.115,<1.0",
+    # Pinned exactly: an unpinned minor bump to 0.139 changed how include_router()
+    # wraps routes, which silently disabled slowapi's rate limiting in production
+    # while the tests stayed green. Bumps go through a PR, not through resolution.
+    "fastapi==0.139.2",
     "uvicorn[standard]==0.51.0",
     "pydantic>=2.7,<3.0",
     # Database
@@ -25,7 +28,9 @@ dependencies = [
     "python-multipart==0.0.31",
     "alembic>=1.18.5",
     "filetype>=1.2.0",
-    "slowapi>=0.1.10",
+    # Rate limiting is built straight on `limits` (see apps/shared/rate_limit.py);
+    # slowapi was dropped because its route-introspection approach broke silently.
+    "limits==5.8.0",
     "pydantic-settings>=2.14.2",
     "structlog>=26.1.0",
 ]

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,33 +1,84 @@
-"""Rate limiting is wired into every app via the shared factory."""
+"""Rate limiting is enforced on the routes production actually serves.
 
-from fastapi import FastAPI
+The previous version of this test registered its probe with ``@app.get()``
+directly on a bare FastAPI instance. That is not how any real endpoint is
+mounted — every app builds its routes through ``create_app()`` +
+``include_versioned()`` — and the difference mattered: the old slowapi-based
+limiter resolved limits via the matched route's ``.endpoint`` attribute, which
+router-included routes don't have, so production was unlimited while this test
+stayed green. Every probe below therefore goes through the real factory.
+"""
+
+import pytest
+from fastapi import APIRouter, FastAPI
 from starlette.testclient import TestClient
 
+from apps.shared.app_factory import create_app, include_versioned
 from apps.shared.config import settings
-from apps.shared.rate_limit import setup_rate_limiting
 
 
-def _app_with_ping() -> FastAPI:
-    app = FastAPI()
-    setup_rate_limiting(app)
+@pytest.fixture
+def app(monkeypatch) -> FastAPI:
+    # setup_rate_limiting reads the setting at call time; patch the singleton
+    # (the cached Settings won't pick up an env change).
+    monkeypatch.setattr(settings, "rate_limit_default", "3/minute")
+    app = create_app(title="probe", url_prefix="probe")
+    router = APIRouter(prefix="/probe")
 
-    @app.get("/ping")
+    @router.get("/ping")
     def ping():
         return {"ok": True}
 
+    @router.get("/health")
+    def health():
+        return {"status": "ok"}
+
+    include_versioned(app, router)
     return app
 
 
-def test_default_limit_returns_429_when_exceeded(monkeypatch):
-    # setup_rate_limiting reads settings.rate_limit_default at call time; patch
-    # the singleton (the cached Settings won't pick up an env change).
-    monkeypatch.setattr(settings, "rate_limit_default", "3/minute")
-    client = TestClient(_app_with_ping())
-    codes = [client.get("/ping").status_code for _ in range(5)]
-    assert codes[:3] == [200, 200, 200]
-    assert 429 in codes, codes
+def _codes(client: TestClient, path: str, n: int) -> list[int]:
+    return [client.get(path).status_code for _ in range(n)]
 
 
-def test_ratelimit_headers_emitted():
-    headers = {k.lower() for k in TestClient(_app_with_ping()).get("/ping").headers}
-    assert "x-ratelimit-limit" in headers
+def test_router_included_route_is_limited(app):
+    # The regression that mattered: this path was completely exempt.
+    assert _codes(TestClient(app), "/probe/ping", 5) == [200, 200, 200, 429, 429]
+
+
+def test_versioned_alias_shares_the_same_bucket(app):
+    client = TestClient(app)
+    _codes(client, "/probe/ping", 3)
+    # /v1/... and the bare alias are the same endpoint; hitting one must not
+    # hand the caller a fresh allowance on the other.
+    assert client.get("/v1/probe/ping").status_code == 429
+
+
+def test_separate_clients_get_separate_buckets(app):
+    client = TestClient(app)
+    _codes(client, "/probe/ping", 5)
+    other = {"x-forwarded-for": "203.0.113.50"}
+    assert client.get("/probe/ping", headers=other).status_code == 200
+
+
+def test_healthcheck_paths_are_never_throttled(app):
+    client = TestClient(app)
+    _codes(client, "/probe/ping", 5)  # exhaust the caller's allowance
+    # Container healthchecks poll these; throttling them would make autoheal
+    # restart a healthy container.
+    assert client.get("/probe/health").status_code == 200
+    assert client.get("/probe/openapi.json").status_code == 200
+
+
+def test_limit_headers_are_emitted(app):
+    resp = TestClient(app).get("/probe/ping")
+    assert resp.headers["X-RateLimit-Limit"] == "3"
+    assert resp.headers["X-RateLimit-Remaining"] == "2"
+
+
+def test_429_tells_the_caller_when_to_retry(app):
+    client = TestClient(app)
+    _codes(client, "/probe/ping", 4)
+    resp = client.get("/probe/ping")
+    assert resp.status_code == 429
+    assert 0 < int(resp.headers["Retry-After"]) <= 60

--- a/uv.lock
+++ b/uv.lock
@@ -105,11 +105,11 @@ dependencies = [
     { name = "fastapi" },
     { name = "filetype" },
     { name = "httpx" },
+    { name = "limits" },
     { name = "psycopg2-binary" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-multipart" },
-    { name = "slowapi" },
     { name = "sqlalchemy" },
     { name = "stravalib" },
     { name = "structlog" },
@@ -130,14 +130,14 @@ requires-dist = [
     { name = "aiofiles", specifier = "==25.1.0" },
     { name = "alembic", specifier = ">=1.18.5" },
     { name = "cryptography", specifier = "==48.0.1" },
-    { name = "fastapi", specifier = ">=0.115,<1.0" },
+    { name = "fastapi", specifier = "==0.139.2" },
     { name = "filetype", specifier = ">=1.2.0" },
     { name = "httpx", specifier = ">=0.28,<0.29" },
+    { name = "limits", specifier = "==5.8.0" },
     { name = "psycopg2-binary", specifier = "==2.9.12" },
     { name = "pydantic", specifier = ">=2.7,<3.0" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "python-multipart", specifier = "==0.0.31" },
-    { name = "slowapi", specifier = ">=0.1.10" },
     { name = "sqlalchemy", specifier = ">=2.0.35,<2.1" },
     { name = "stravalib", specifier = ">=2.5,<3.0" },
     { name = "structlog", specifier = ">=26.1.0" },
@@ -871,18 +871,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
-]
-
-[[package]]
-name = "slowapi"
-version = "0.1.10"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "limits" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/52/24527cf25a8b508926aff53350b0136561dfe86c7125f61526653666e1b2/slowapi-0.1.10.tar.gz", hash = "sha256:d320d5bc04d9f171a77fb16700faf3036d85b00f420f22924c8a225f95bd14f9", size = 13841, upload-time = "2026-06-13T11:59:31.571Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/8b/1d359f38706b4097d9a943bf8bd22599f537de4cbaff1e622d3e3936e164/slowapi-0.1.10-py3-none-any.whl", hash = "sha256:3acb61561dc9d687e3d3669362ff6a439de9ba44e2fed3a9c165da26b4b83e28", size = 14921, upload-time = "2026-06-13T11:59:30.485Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
> **Stacked på #87** — merge #87 først.

## Problem

Rate limiting var **helt inert på alle ekte endepunkter**.

slowapi finner en requests limit ved å slå opp `.endpoint` på den matchede ruta. FastAPI 0.139 pakker `include_router()`-ruter i et objekt **uten** `.endpoint` → `_find_route_handler()` returnerer `None` → `_should_exempt()` returnerer `True`. Alt som mountes via `include_versioned()` — altså hvert eneste endepunkt i repoet — var unntatt. Kun de tre rutene som registreres direkte i `create_app()` ble limitert.

Verifisert mot ekte uvicorn **før** fiksen, med grense `5/minute`:

```
/site/health x8:      200 200 200 200 200 200 200 200
/v1/site/health x8:   200 200 200 200 200 200 200 200
```

### Hvorfor testen ikke fanget det

`tests/test_rate_limit.py` registrerte proben sin med `@app.get("/ping")` på en naken `FastAPI()`. Det er ikke slik noe endepunkt mountes. Testen var grønn mens produksjon var ubeskyttet — falsk trygghet.

> Merk: prod var *i praksis* dekket, men av **Caddy** på kanten (`server: Caddy`, `"You're being rate limited kid"`), ikke av appen. Så dette var tapt defense-in-depth, ikke en åpen dør.

## Endringer

- Rate limiting bygger nå rett på `limits`, nøklet **kun** på klient-IP. Ingen route-introspeksjon å regge på. slowapi fjernet.
- `/health` og `/openapi.json` er unntatt — throttling der ville fått autoheal til å restarte en frisk container.
- Testene mountes gjennom ekte `create_app()` + `include_versioned()`, og dekker nå versjonert alias (samme bøtte), per-IP-isolasjon, headers og `Retry-After`.
- `fastapi==0.139.2` pinnet. Den uspesifiserte range-en er *årsaken* til at dette knakk stille.

## Verifisert etter fiks (ekte uvicorn, 5/minute)

```
/site/visit x8:        200 200 200 200 200 429 429 429
/site/health x8:       200 200 200 200 200 200 200 200   (unntatt)
annen IP via XFF:      200                                (egen bøtte)
```

`53 passed, 2 skipped`, ruff + mypy grønt.