### PR TITLE
fix(security): cap request body size before FastAPI parses it

### DIFF
--- a/.github/DEPLOYMENT.md
+++ b/.github/DEPLOYMENT.md
@@ -81,6 +81,22 @@ handle_path /n8n/* {
 }
 ```
 
+## Kroppsstørrelse på requests (Caddy)
+
+Appene avviser selv requests som *oppgir* en `Content-Length` over
+`MAX_REQUEST_BODY_BYTES` (default 11 MB). En request som utelater headeren og
+bruker chunked transfer-encoding kan ikke vurderes på forhånd — der er Caddy
+eneste forsvar. Legg derfor dette i `api.vuhnger.dev`-blokka i Caddyfile:
+
+```
+request_body {
+    max_size 11MB
+}
+```
+
+Uten den kan en uautentisert klient strømme vilkårlig mange GB inn på disken før
+noe lag rekker å avvise den.
+
 ## Feilsøking
 
 Hvis deployment feiler:

--- a/apps/shared/app_factory.py
+++ b/apps/shared/app_factory.py
@@ -13,7 +13,9 @@ from fastapi import APIRouter, FastAPI
 from fastapi.openapi.docs import get_swagger_ui_oauth2_redirect_html
 from fastapi.staticfiles import StaticFiles
 
+from apps.shared.body_limit import BodySizeLimitMiddleware
 from apps.shared.cache_control_headers import setup_cache_control
+from apps.shared.config import settings
 from apps.shared.cors import setup_cors
 from apps.shared.logging_config import configure_logging
 from apps.shared.rate_limit import setup_rate_limiting
@@ -55,10 +57,15 @@ def create_app(
     )
 
     # Shared middleware, applied in one place so hardening can't drift per-app.
+    # The body cap is added last so it ends up outermost: an oversized request
+    # must be refused before any other layer — or FastAPI itself — reads it.
     setup_cors(app)
     setup_cache_control(app)
     setup_security_headers(app)
     setup_rate_limiting(app)
+    app.add_middleware(
+        BodySizeLimitMiddleware, max_bytes=settings.max_request_body_bytes
+    )
 
     # Serve Swagger UI assets locally (no third-party CDN) so the strict CSP applies.
     app.mount("/static", StaticFiles(directory="static"), name="static")

--- a/apps/shared/body_limit.py
+++ b/apps/shared/body_limit.py
@@ -1,0 +1,54 @@
+"""Reject oversized request bodies before anything reads them.
+
+FastAPI parses the whole multipart body — spooling file parts to disk without a
+cap — *before* it resolves dependencies. So the upload endpoint's own size and
+API-key checks both run after an attacker's bytes have already landed: an
+unauthenticated 25 MB POST is fully written to the host before the 401 is
+returned. On a 19 GB box that has filled up once already, concurrent uploads are
+a cheap way to take the whole stack down.
+
+This runs as raw ASGI middleware rather than ``@app.middleware("http")`` so it
+sees the request before any body parsing happens.
+
+Limitation: a request that omits ``Content-Length`` (chunked transfer-encoding)
+can't be judged up front. Caddy is the backstop for that case — see the
+``request_body max_size`` directive documented in .github/DEPLOYMENT.md.
+"""
+
+from starlette.datastructures import Headers
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+_TOO_LARGE_BODY = b'{"detail":"Request body too large"}'
+
+
+class BodySizeLimitMiddleware:
+    """Answer 413 to any request that declares a body larger than ``max_bytes``."""
+
+    def __init__(self, app: ASGIApp, max_bytes: int) -> None:
+        self.app = app
+        self.max_bytes = max_bytes
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        declared = Headers(scope=scope).get("content-length")
+        if declared and declared.isdigit() and int(declared) > self.max_bytes:
+            await self._reject(send)
+            return
+
+        await self.app(scope, receive, send)
+
+    async def _reject(self, send: Send) -> None:
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 413,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"content-length", str(len(_TOO_LARGE_BODY)).encode()),
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": _TOO_LARGE_BODY})

--- a/apps/shared/config.py
+++ b/apps/shared/config.py
@@ -40,6 +40,11 @@ class Settings(BaseSettings):
     rate_limit_default: str = "120/minute"
     rate_limit_storage_uri: str | None = None
 
+    # Largest request body any app will accept, in bytes. Sized just above the
+    # projects app's 10 MB image limit to leave room for multipart overhead;
+    # everything else needs far less.
+    max_request_body_bytes: int = 11 * 1024 * 1024
+
     # Strava OAuth
     strava_client_id: str | None = None
     strava_client_secret: str | None = None

--- a/tests/test_body_limit.py
+++ b/tests/test_body_limit.py
@@ -1,0 +1,55 @@
+"""Oversized bodies are refused before anything reads them.
+
+The upload endpoint's own size check runs after FastAPI has already parsed the
+multipart body and spooled its file parts to disk — and after the API-key
+dependency, so an unauthenticated request could land 25 MB on the host and still
+get a 401. This cap has to bite earlier than all of that.
+"""
+
+import pytest
+from fastapi import APIRouter
+from starlette.testclient import TestClient
+
+from apps.shared.app_factory import create_app, include_versioned
+from apps.shared.config import settings
+
+LIMIT = 1024
+
+
+@pytest.fixture
+def client(monkeypatch) -> TestClient:
+    monkeypatch.setattr(settings, "max_request_body_bytes", LIMIT)
+    monkeypatch.setattr(settings, "rate_limit_default", "1000/minute")
+    app = create_app(title="probe", url_prefix="probe")
+    router = APIRouter(prefix="/probe")
+    consumed: list[int] = []
+
+    @router.post("/echo")
+    async def echo(body: bytes = b""):
+        consumed.append(len(body))
+        return {"len": len(body)}
+
+    include_versioned(app, router)
+    client = TestClient(app)
+    client.consumed = consumed  # type: ignore[attr-defined]
+    return client
+
+
+def test_oversized_body_is_rejected_with_413(client):
+    resp = client.post("/probe/echo", content=b"x" * (LIMIT + 1))
+    assert resp.status_code == 413
+    assert resp.json() == {"detail": "Request body too large"}
+
+
+def test_the_handler_never_sees_an_oversized_body(client):
+    # The whole point: rejection happens before the body reaches application code.
+    client.post("/probe/echo", content=b"x" * (LIMIT * 100))
+    assert client.consumed == []
+
+
+def test_body_at_the_limit_is_accepted(client):
+    assert client.post("/probe/echo", content=b"x" * LIMIT).status_code != 413
+
+
+def test_requests_without_a_body_are_unaffected(client):
+    assert client.get("/probe/openapi.json").status_code == 200


### PR DESCRIPTION
> **Stacket på #88** (som igjen står på #87). Merge i rekkefølge 87 → 88 → denne.

## Problem

FastAPI parser hele multipart-bodyen — og spooler fil-deler til disk **uten tak** — *før* den resolver dependencies. Begge vaktene i `/projects/upload-image` kommer derfor for sent:

| Sjekk | Kjører | Bytes allerede på disk |
|---|---|---|
| `Depends(get_api_key)` | etter parsing | alle |
| `file.size > MAX_FILE_SIZE` | etter parsing | alle |

En **uautentisert** 25 MB POST skrives i sin helhet til hosten og får så `401`. Serveren din har 19 GB disk og har gått full én gang før — samtidige opplastinger er en billig måte å ta ned hele stacken på.

## Endringer

- `BodySizeLimitMiddleware` — rå ASGI, så den kjører før all body-parsing. Lagt til ytterst i `create_app()`, gjelder alle tjenester.
- `MAX_REQUEST_BODY_BYTES`, default 11 MB (like over projects-appens 10 MB bildegrense, med rom for multipart-overhead).
- Dokumentert `request_body { max_size 11MB }` i Caddy: en chunked request utelater `Content-Length` og kan kun stoppes på proxyen.

## Test

4 nye tester, inkludert at handleren **aldri ser** en for stor body (ikke bare at statuskoden er riktig).