### PR TITLE
fix(site): bound every attacker-controlled input on the visit beacon

### DIFF
--- a/apps/shared/config.py
+++ b/apps/shared/config.py
@@ -67,6 +67,11 @@ class Settings(BaseSettings):
     visit_notify_throttle_seconds: int = 3600  # at most one ping per IP per hour
     visit_notify_exclude_ips: str = ""         # comma-separated IPs to ignore (e.g. yours)
 
+    # IP -> location lookup for the visit notification. `{ip}` is substituted with
+    # a validated address. The default provider's free tier is HTTP-only; point
+    # this at an HTTPS provider to stop leaking visitor IPs in the clear.
+    geo_lookup_url: str = "http://ip-api.com/json/{ip}"
+
     @property
     def is_production(self) -> bool:
         return self.environment == "production"

--- a/apps/site/main.py
+++ b/apps/site/main.py
@@ -6,13 +6,15 @@ real-time "someone's here" ping. No DB — throttling is in-memory, which is fin
 for this single-worker deployment.
 """
 
+import ipaddress
 import logging
 import time
+from collections import OrderedDict
 from urllib.parse import parse_qs, urlsplit
 
 import httpx
 from fastapi import APIRouter, BackgroundTasks, Request
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from apps.shared.app_factory import create_app, include_versioned
 from apps.shared.config import settings
@@ -28,8 +30,17 @@ app = create_app(
 )
 router = APIRouter(prefix="/site")
 
-# In-memory throttle: client IP -> epoch seconds of last notification.
-_last_notified: dict[str, float] = {}
+# In-memory throttle: client IP -> epoch seconds of last notification. Ordered so
+# the oldest entry can be evicted once the map is full — expiry alone isn't enough,
+# because a burst of distinct IPs produces entries that are all still fresh.
+_MAX_TRACKED_IPS = 10_000
+_last_notified: OrderedDict[str, float] = OrderedDict()
+
+# Longest values we'll echo into a push notification. The payload is public and
+# unauthenticated, so without a cap a single request can fabricate a multi-megabyte
+# notification body.
+_MAX_FIELD_LEN = 300
+_MAX_SOURCE_LEN = 100
 
 # Substrings that mark a request as a bot/crawler/monitor we don't want pinged for.
 _BOT_MARKERS = (
@@ -46,8 +57,10 @@ _CAMPAIGN_PARAMS = ("utm_source", "ref", "source")
 class VisitIn(BaseModel):
     # `path` may include the query string (e.g. "/?utm_source=linkedin") — send
     # `location.pathname + location.search` from the frontend to get campaign data.
-    path: str | None = None
-    referrer: str | None = None
+    # Both fields are length-capped: pydantic rejects anything longer with a 422,
+    # so oversized values never reach the notifier.
+    path: str | None = Field(default=None, max_length=_MAX_FIELD_LEN)
+    referrer: str | None = Field(default=None, max_length=_MAX_FIELD_LEN)
 
 
 def _looks_like_bot(user_agent: str) -> bool:
@@ -63,23 +76,44 @@ def _throttle_ok(ip: str) -> bool:
     if last is not None and now - last < window:
         return False
     _last_notified[ip] = now
-    if len(_last_notified) > 10_000:  # opportunistic cleanup of stale entries
-        cutoff = now - window
-        for stale in [k for k, v in _last_notified.items() if v < cutoff]:
-            _last_notified.pop(stale, None)
+    _last_notified.move_to_end(ip)
+
+    # Drop expired entries first, then — if the map is still full — the oldest
+    # ones. The expiry sweep alone leaves the map unbounded, because entries only
+    # become droppable after a full window has passed.
+    cutoff = now - window
+    for stale in [k for k, v in _last_notified.items() if v < cutoff]:
+        del _last_notified[stale]
+    while len(_last_notified) > _MAX_TRACKED_IPS:
+        _last_notified.popitem(last=False)
     return True
 
 
 def _geo(ip: str) -> str:
-    """Best-effort 'City, Country' from IP. Never raises; '' on any failure."""
+    """Best-effort 'City, Country' from IP. Never raises; '' on any failure.
+
+    The address is validated before it reaches the URL so a malformed value can't
+    shape the outbound request, and private/loopback addresses are skipped — a
+    lookup for them is guaranteed useless. Note the provider's free tier is
+    plaintext HTTP, so visitor IPs travel in the clear; ``GEO_LOOKUP_URL`` exists
+    so that can be pointed at an HTTPS provider without a code change.
+    """
+    try:
+        parsed = ipaddress.ip_address(ip)
+    except ValueError:
+        return ""
+    if parsed.is_private or parsed.is_loopback or parsed.is_reserved:
+        return ""
+
     try:
         resp = httpx.get(
-            f"http://ip-api.com/json/{ip}",
+            settings.geo_lookup_url.format(ip=parsed),
             params={"fields": "country,city"},
             timeout=3.0,
         )
         data = resp.json()
-        return ", ".join(p for p in (data.get("city"), data.get("country")) if p)
+        located = ", ".join(p for p in (data.get("city"), data.get("country")) if p)
+        return located[:_MAX_SOURCE_LEN]
     except Exception:
         return ""
 
@@ -106,7 +140,9 @@ def _source(referrer: str | None, path: str | None) -> str:
     """
     campaign = _campaign(path)
     if referrer:
-        host = urlsplit(referrer).netloc or referrer
+        # A referrer without a scheme has no netloc, so the raw value is the
+        # fallback — cap it, since it's attacker-supplied and ends up in a push.
+        host = (urlsplit(referrer).netloc or referrer)[:_MAX_SOURCE_LEN]
         return f"{host} · {campaign}" if campaign else host
     if campaign:
         return f"{campaign} (utm)"

--- a/tests/test_visit_notifications.py
+++ b/tests/test_visit_notifications.py
@@ -114,3 +114,40 @@ def test_source_is_always_reported(referrer, path, expected):
 def test_notification_body_always_carries_a_source(notifier_mock):
     _post("9.9.9.5", referrer="", path="/")  # browser sent no referrer at all
     assert "↩︎ direct / unknown" in notifier_mock.send.call_args.args[0]
+
+
+# --- abuse resistance ------------------------------------------------------
+
+def test_oversized_fields_are_rejected_before_reaching_the_notifier(notifier_mock):
+    # Unbounded input here meant one request could fabricate a multi-megabyte push.
+    resp = TestClient(site.app).post(
+        "/site/visit",
+        json={"path": "/" + "a" * 5000, "referrer": "b" * 5000},
+        headers={"x-forwarded-for": "9.9.9.4", "user-agent": "Mozilla/5.0"},
+    )
+    assert resp.status_code == 422
+    assert notifier_mock.send.call_count == 0
+
+
+def test_schemeless_referrer_is_truncated_in_the_message():
+    assert len(site._source("x" * 250, "/")) == site._MAX_SOURCE_LEN
+
+
+def test_throttle_map_stays_bounded_under_distinct_ips(monkeypatch):
+    # Every entry stays fresh under a burst of new IPs, so expiry alone can't
+    # bound the map — it has to evict the oldest too.
+    site._last_notified.clear()
+    monkeypatch.setattr(site, "_MAX_TRACKED_IPS", 50)
+    for i in range(500):
+        site._throttle_ok(f"198.51.100.{i}")
+    assert len(site._last_notified) <= 50
+
+
+def test_geo_skips_addresses_that_cannot_resolve(monkeypatch):
+    def explode(*a, **kw):  # any outbound call here is a bug
+        raise AssertionError("should not perform a lookup")
+
+    monkeypatch.setattr(site.httpx, "get", explode)
+    assert site._geo("10.0.0.5") == ""      # private
+    assert site._geo("127.0.0.1") == ""     # loopback
+    assert site._geo("not-an-ip") == ""     # malformed


### PR DESCRIPTION
> **Stacket på #89** (87 → 88 → 89 → denne).

## Problem

`/site/visit` er offentlig og uautentisert, og alt den tar imot havner som en push på telefonen din. Tre ting var ubegrenset:

| Hva | Konsekvens |
|---|---|
| `path` / `referrer` uten lengdegrense | Én request → **4 MB** utgående POST til ntfy, og vilkårlig tekst på telefonen din |
| `_last_notified` evicter kun *utløpte* entries | En byge av distinkte IP-er gir bare ferske entries → kartet vokser ubegrenset |
| `_geo()` interpolerer IP rett inn i provider-URL-en | Ingen validering; private/loopback-adresser brenner et kall som aldri kan lykkes |

## Endringer

- `path`/`referrer` kappet til 300 tegn (pydantic → 422 før noe når notifieren). `_source()` kapper også den schemeless referrer-fallbacken den ellers ekkoer rått.
- Throttle-kartet dropper eldste entry når det er fullt — utløp alene kan ikke begrense det.
- `_geo()` validerer adressen først, og hopper over private/loopback/reserved.
- Provider-URL flyttet til `GEO_LOOKUP_URL`. Gratisnivået til ip-api er **HTTP**, så besøkendes IP-er går i klartekst i dag — nå kan du bytte provider uten kodeendring.

## Test

4 nye tester. `61 passed, 2 skipped`.