### PR TITLE
fix(oauth): isolate and serialize token refresh; fix WakaTime parsing

### DIFF
--- a/apps/shared/oauth_tokens.py
+++ b/apps/shared/oauth_tokens.py
@@ -1,0 +1,143 @@
+"""Shared OAuth token refresh.
+
+Both providers had their own near-identical copy of this, and both copies shared
+two defects:
+
+**The refresh committed on the caller's session.** ``get_valid_token(db)`` is
+called from the middle of a sync task that has already queued bulk activity
+upserts on the same session. A refresh triggering there committed that
+half-finished sync — and if the refresh then failed, its ``rollback()`` threw the
+pending upserts away. The refresh now runs in its own short-lived session, so it
+can never commit or discard the caller's work.
+
+**Read-check-refresh had no lock.** Two callers (the cron sync and a manual
+/refresh-data, say) could both see an expiring token and both POST the same
+refresh token. Providers rotate refresh tokens, so the second response
+invalidates the first and the stored token can end up permanently dead —
+requiring a manual re-authorization. The refresh now takes a row lock and
+re-checks after acquiring it, so the second caller finds the work already done.
+"""
+
+import logging
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+from urllib.parse import parse_qs
+
+import httpx
+
+from apps.shared.database import SessionLocal
+
+logger = logging.getLogger(__name__)
+
+# Every outbound call needs a timeout; a hung provider must not pin a worker.
+HTTP_TIMEOUT = 10.0
+
+# Used only when a provider's response carries no parseable expiry at all. Short
+# and loudly logged: guessing long would hand out a token we believe in but the
+# provider has already rejected.
+_FALLBACK_EXPIRY_SECONDS = 3600
+
+
+@dataclass(frozen=True)
+class TokenSet:
+    """The three fields every refresh has to produce."""
+
+    access_token: str
+    refresh_token: str
+    expires_at: int
+
+
+def needs_refresh(expires_at: int, buffer_seconds: int = 300) -> bool:
+    """True if the token expires within ``buffer_seconds``."""
+    return time.time() >= (expires_at - buffer_seconds)
+
+
+def parse_token_response(response: httpx.Response) -> dict[str, Any]:
+    """Decode a token response as JSON, falling back to form-encoded.
+
+    WakaTime answers ``application/x-www-form-urlencoded`` rather than JSON. The
+    OAuth callback handled that; the refresh path did not, and called ``.json()``
+    directly — so refresh raised ``ValueError`` on every attempt while the initial
+    authorization worked, and the integration died about an hour after each login.
+    """
+    try:
+        return response.json()
+    except ValueError:
+        return {key: values[0] for key, values in parse_qs(response.text).items() if values}
+
+
+def parse_expiry(token_data: dict[str, Any]) -> int:
+    """Absolute expiry (unix seconds) from a token response.
+
+    Accepts ``expires_in`` (seconds from now), a numeric ``expires_at``, or an
+    ISO-8601 ``expires_at``. The previous WakaTime code read ``expires_at``,
+    discarded it, and stored ``now + 3600`` regardless — so the stored expiry was
+    fiction and the token was refreshed roughly hourly no matter what.
+    """
+    now = int(time.time())
+
+    if "expires_in" in token_data:
+        return now + int(float(token_data["expires_in"]))
+
+    raw = token_data.get("expires_at")
+    if raw is not None:
+        try:
+            return int(float(raw))
+        except (TypeError, ValueError):
+            pass
+        try:
+            text = str(raw).replace("Z", "+00:00")
+            return int(datetime.fromisoformat(text).timestamp())
+        except ValueError:
+            pass
+
+    logger.error(
+        "token response carried no parseable expiry (keys: %s); assuming %ds",
+        sorted(token_data), _FALLBACK_EXPIRY_SECONDS,
+    )
+    return now + _FALLBACK_EXPIRY_SECONDS
+
+
+def refresh_token_locked(
+    model: type[Any],
+    exchange: Callable[[str], TokenSet],
+    buffer_seconds: int,
+) -> None:
+    """Refresh the stored grant under a row lock, in an isolated session.
+
+    Args:
+        model: The auth model holding the single-user row (id=1).
+        exchange: Given the current refresh token, performs the provider call and
+            returns the new ``TokenSet``.
+        buffer_seconds: Re-check window; if another caller already refreshed while
+            this one waited for the lock, there is nothing left to do.
+
+    Raises:
+        ValueError: If no authorization row exists yet.
+    """
+    session = SessionLocal()
+    try:
+        auth = session.query(model).filter(model.id == 1).with_for_update().first()
+        if auth is None:
+            raise ValueError(
+                f"No {model.__tablename__} row found. Complete the OAuth flow first."
+            )
+
+        # Double-checked under the lock: whoever held it before us may already
+        # have done this exact refresh, and reusing a rotated token would fail.
+        if not needs_refresh(auth.expires_at, buffer_seconds):
+            return
+
+        tokens = exchange(auth.refresh_token)
+        auth.access_token = tokens.access_token
+        auth.refresh_token = tokens.refresh_token
+        auth.expires_at = tokens.expires_at
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()

--- a/apps/strava/utils.py
+++ b/apps/strava/utils.py
@@ -1,95 +1,69 @@
 """
 Utility functions for Strava token management
 """
-import time
-from typing import Any
-
 import httpx
 from sqlalchemy.orm import Session
 
 from apps.shared.config import settings
+from apps.shared.oauth_tokens import (
+    HTTP_TIMEOUT,
+    TokenSet,
+    needs_refresh,
+    parse_expiry,
+    parse_token_response,
+    refresh_token_locked,
+)
 from apps.strava.models import StravaAuth
 
-# Every outbound call needs a timeout; a hung Strava endpoint must not pin a worker.
-HTTP_TIMEOUT = 10.0
+# Strava access tokens last 6 hours; refresh an hour ahead of expiry.
+REFRESH_BUFFER_SECONDS = 3600
 
 
-def is_token_expired(expires_at: int) -> bool:
-    """Check if token has expired"""
-    return time.time() >= expires_at
-
-
-def needs_refresh(expires_at: int, buffer_seconds: int = 3600) -> bool:
-    """Check if token expires within buffer time (default 1 hour)"""
-    return time.time() >= (expires_at - buffer_seconds)
-
-
-def refresh_strava_token(db: Session) -> dict[str, Any]:
-    """
-    Refresh Strava access token using refresh token.
-    Returns new token data or raises exception.
-
-    Rolls back database changes if token refresh or update fails.
-    """
-    # Get current auth (single user, id=1)
-    auth = db.query(StravaAuth).filter(StravaAuth.id == 1).first()
-
-    if not auth:
-        raise ValueError("No Strava authentication found. Please complete OAuth flow first.")
-
-    # Prepare token refresh request
+def _exchange_refresh_token(refresh_token: str) -> TokenSet:
+    """Trade a refresh token for a new grant at Strava."""
     client_id = settings.strava_client_id
     client_secret = settings.strava_client_secret
-
     if not client_id or not client_secret:
         raise ValueError("Strava credentials not configured")
 
-    try:
-        # Request new tokens from Strava
-        response = httpx.post(
-            "https://www.strava.com/oauth/token",
-            data={
-                "client_id": client_id,
-                "client_secret": client_secret,
-                "grant_type": "refresh_token",
-                "refresh_token": auth.refresh_token
-            },
-            timeout=HTTP_TIMEOUT,
-        )
+    response = httpx.post(
+        "https://www.strava.com/oauth/token",
+        data={
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+        },
+        timeout=HTTP_TIMEOUT,
+    )
+    if response.status_code != 200:
+        # The provider's raw body can carry request details; keep it out of the
+        # exception message and let the status code identify the failure.
+        raise RuntimeError(f"Strava token refresh failed with HTTP {response.status_code}")
 
-        if response.status_code != 200:
-            raise Exception(f"Failed to refresh token: {response.text}")
+    token_data = parse_token_response(response)
+    return TokenSet(
+        access_token=token_data["access_token"],
+        refresh_token=token_data["refresh_token"],
+        expires_at=parse_expiry(token_data),
+    )
 
-        token_data = response.json()
 
-        # Update database with new tokens
-        auth.access_token = token_data["access_token"]
-        auth.refresh_token = token_data["refresh_token"]
-        auth.expires_at = token_data["expires_at"]
-        db.commit()
-
-        return token_data
-
-    except Exception:
-        # Rollback on any failure (network, API, or database)
-        db.rollback()
-        raise
+def refresh_strava_token() -> None:
+    """Refresh the stored Strava grant under a row lock, in its own session."""
+    refresh_token_locked(StravaAuth, _exchange_refresh_token, REFRESH_BUFFER_SECONDS)
 
 
 def get_valid_token(db: Session) -> str:
-    """
-    Get a valid access token, refreshing if necessary.
-    Returns access token string.
-    """
+    """Return a currently-valid access token, refreshing first if needed."""
     auth = db.query(StravaAuth).filter(StravaAuth.id == 1).first()
-
     if not auth:
         raise ValueError("No Strava authentication found. Please complete OAuth flow first.")
 
-    # Check if token needs refresh
-    if needs_refresh(auth.expires_at):
-        refresh_strava_token(db)
-        # Reload auth after refresh
-        auth = db.query(StravaAuth).filter(StravaAuth.id == 1).first()
+    if needs_refresh(auth.expires_at, REFRESH_BUFFER_SECONDS):
+        refresh_strava_token()
+        # The refresh committed on a separate session, so this one still holds the
+        # pre-refresh row; re-read it rather than handing out the dead token.
+        db.refresh(auth)
 
     return auth.access_token

--- a/apps/wakatime/main.py
+++ b/apps/wakatime/main.py
@@ -17,6 +17,7 @@ from apps.shared.encryption import encrypt_token
 from apps.shared.errors import log_and_sanitize_error
 from apps.shared.oauth_owner import enforce_owner
 from apps.shared.oauth_state import generate_state, validate_state
+from apps.shared.oauth_tokens import parse_expiry, parse_token_response
 from apps.shared.upsert import atomic_upsert_auth
 from apps.wakatime.models import WakaTimeAuth, WakaTimeStats
 from apps.wakatime.tasks import fetch_and_cache_wakatime_stats
@@ -90,26 +91,12 @@ def oauth_callback(
         response = httpx.post(token_url, data=data, timeout=10.0)
         response.raise_for_status()
 
-        try:
-            token_data = response.json()
-        except ValueError:
-            # WakaTime sometimes returns application/x-www-form-urlencoded body
-            from urllib.parse import parse_qs
-
-            parsed = parse_qs(response.text)
-            # parse_qs returns lists, we need single values
-            token_data = {k: v[0] for k, v in parsed.items()}
-
+        # WakaTime answers form-encoded rather than JSON; both decodings and the
+        # expiry handling are shared with the refresh path so the two can't drift.
+        token_data = parse_token_response(response)
         access_token = token_data["access_token"]
         refresh_token = token_data["refresh_token"]
-        expires_at = int(
-            float(token_data.get("expires_in", 3600))
-        )  # Not absolute time yet?
-
-        # Actually standard OAuth 'expires_in' is seconds from now.
-        import time
-
-        expires_at_timestamp = int(time.time()) + expires_at
+        expires_at_timestamp = parse_expiry(token_data)
 
         # Get user info for ID
         user_resp = httpx.get(

--- a/apps/wakatime/utils.py
+++ b/apps/wakatime/utils.py
@@ -1,121 +1,75 @@
 """
 Utility functions for WakaTime token management
 """
-import time
-from typing import Any
-
 import httpx
 from sqlalchemy.orm import Session
 
 from apps.shared.config import settings
+from apps.shared.oauth_tokens import (
+    HTTP_TIMEOUT,
+    TokenSet,
+    needs_refresh,
+    parse_expiry,
+    parse_token_response,
+    refresh_token_locked,
+)
 from apps.wakatime.models import WakaTimeAuth
 
-# Every outbound call needs a timeout; a hung WakaTime endpoint must not pin a worker.
-HTTP_TIMEOUT = 10.0
+# WakaTime access tokens are long-lived; refresh five minutes ahead of expiry.
+REFRESH_BUFFER_SECONDS = 300
 
 
-def is_token_expired(expires_at: int) -> bool:
-    """Check if token has expired"""
-    return time.time() >= expires_at
+def _exchange_refresh_token(refresh_token: str) -> TokenSet:
+    """Trade a refresh token for a new grant at WakaTime.
 
-
-def needs_refresh(expires_at: int, buffer_seconds: int = 300) -> bool:
-    """Check if token expires within buffer time (default 5 minutes)"""
-    return time.time() >= (expires_at - buffer_seconds)
-
-
-def refresh_wakatime_token(db: Session) -> dict[str, Any]:
+    WakaTime answers form-encoded rather than JSON, which is why the response goes
+    through ``parse_token_response`` — calling ``.json()`` here (as this used to)
+    raised on every refresh, killing the integration an hour after each login.
     """
-    Refresh WakaTime access token using refresh token.
-    Returns new token data or raises exception.
-
-    Rolls back database changes if token refresh or update fails.
-    """
-    # Get current auth (single user, id=1)
-    auth = db.query(WakaTimeAuth).filter(WakaTimeAuth.id == 1).first()
-
-    if not auth:
-        raise ValueError("No WakaTime authentication found. Please complete OAuth flow first.")
-
-    # Prepare token refresh request
     client_id = settings.wakatime_client_id
     client_secret = settings.wakatime_client_secret
-    redirect_uri = settings.wakatime_redirect_uri
-
     if not client_id or not client_secret:
         raise ValueError("WakaTime credentials not configured")
 
-    try:
-        # Request new tokens from WakaTime
-        # WakaTime uses application/x-www-form-urlencoded
-        data = {
+    response = httpx.post(
+        "https://wakatime.com/oauth/token",
+        data={
             "client_id": client_id,
             "client_secret": client_secret,
             "grant_type": "refresh_token",
-            "refresh_token": auth.refresh_token,
-            "redirect_uri": redirect_uri
-        }
-        
-        response = httpx.post(
-            "https://wakatime.com/oauth/token",
-            data=data,
-            timeout=HTTP_TIMEOUT,
-        )
+            "refresh_token": refresh_token,
+            "redirect_uri": settings.wakatime_redirect_uri,
+        },
+        timeout=HTTP_TIMEOUT,
+    )
+    if response.status_code != 200:
+        # The provider's raw body can carry request details; keep it out of the
+        # exception message and let the status code identify the failure.
+        raise RuntimeError(f"WakaTime token refresh failed with HTTP {response.status_code}")
 
-        if response.status_code != 200:
-            raise Exception(f"Failed to refresh token: {response.text}")
+    token_data = parse_token_response(response)
+    return TokenSet(
+        access_token=token_data["access_token"],
+        refresh_token=token_data["refresh_token"],
+        expires_at=parse_expiry(token_data),
+    )
 
-        token_data = response.json()
-        
-        # WakaTime returns expires_at directly sometimes? Or expires_in?
-        # Standard OAuth is usually expires_in (seconds)
-        # Checking docs: https://wakatime.com/developers#token-response
-        # It returns "expires_at": "Wed, 21 Oct 2015 16:29:20 UTC" OR a timestamp?
-        # Actually usually 'expires_in' but Wakatime might be different.
-        # Let's handle both or standard OAuth 'expires_in'.
-        
-        # Actually, looking at common OAuth, it's usually expires_in.
-        # If wakatime returns expires_in:
-        current_time = int(time.time())
-        if "expires_in" in token_data:
-            new_expires_at = current_time + float(token_data["expires_in"])
-        elif "expires_at" in token_data:
-             # If it's a string date we might need parsing, but hopefully it's consistent.
-             # For now let's assume standard behavior or raw value if we can parse it later.
-             # But saving as int timestamp is best.
-             # Let's assume standard OAuth 2.0 flow for now: expires_in
-             new_expires_at = current_time + 3600 # Fallback
-        else:
-            new_expires_at = current_time + 3600 # Default 1 hour?
 
-        # Update database with new tokens
-        auth.access_token = token_data["access_token"]
-        auth.refresh_token = token_data["refresh_token"]
-        auth.expires_at = int(new_expires_at)
-        db.commit()
-
-        return token_data
-
-    except Exception:
-        # Rollback on any failure (network, API, or database)
-        db.rollback()
-        raise
+def refresh_wakatime_token() -> None:
+    """Refresh the stored WakaTime grant under a row lock, in its own session."""
+    refresh_token_locked(WakaTimeAuth, _exchange_refresh_token, REFRESH_BUFFER_SECONDS)
 
 
 def get_valid_token(db: Session) -> str:
-    """
-    Get a valid access token, refreshing if necessary.
-    Returns access token string.
-    """
+    """Return a currently-valid access token, refreshing first if needed."""
     auth = db.query(WakaTimeAuth).filter(WakaTimeAuth.id == 1).first()
-
     if not auth:
         raise ValueError("No WakaTime authentication found. Please complete OAuth flow first.")
 
-    # Check if token needs refresh
-    if needs_refresh(auth.expires_at):
-        refresh_wakatime_token(db)
-        # Reload auth after refresh
-        auth = db.query(WakaTimeAuth).filter(WakaTimeAuth.id == 1).first()
+    if needs_refresh(auth.expires_at, REFRESH_BUFFER_SECONDS):
+        refresh_wakatime_token()
+        # The refresh committed on a separate session, so this one still holds the
+        # pre-refresh row; re-read it rather than handing out the dead token.
+        db.refresh(auth)
 
     return auth.access_token

--- a/tests/test_oauth_tokens.py
+++ b/tests/test_oauth_tokens.py
@@ -1,0 +1,154 @@
+"""Token refresh: response decoding, expiry, and isolation from the caller.
+
+Each test here corresponds to a defect that was live in both provider apps.
+"""
+
+import time
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from apps.shared import oauth_tokens
+from apps.shared.oauth_tokens import (
+    TokenSet,
+    needs_refresh,
+    parse_expiry,
+    parse_token_response,
+    refresh_token_locked,
+)
+
+# --- response decoding -----------------------------------------------------
+
+def _response(text: str, content_type: str) -> httpx.Response:
+    return httpx.Response(200, text=text, headers={"content-type": content_type})
+
+
+def test_json_response_is_decoded():
+    resp = _response('{"access_token":"a"}', "application/json")
+    assert parse_token_response(resp) == {"access_token": "a"}
+
+
+def test_form_encoded_response_is_decoded():
+    # WakaTime answers form-encoded. The refresh path called .json() directly, so
+    # it raised on every attempt and the integration died ~1h after each login.
+    resp = _response("access_token=a&refresh_token=b", "application/x-www-form-urlencoded")
+    assert parse_token_response(resp) == {"access_token": "a", "refresh_token": "b"}
+
+
+# --- expiry ----------------------------------------------------------------
+
+def test_expires_in_is_relative_to_now():
+    assert parse_expiry({"expires_in": "7200"}) == pytest.approx(time.time() + 7200, abs=2)
+
+
+def test_numeric_expires_at_is_used_verbatim():
+    # The old code read this field, threw the value away, and stored now+3600.
+    assert parse_expiry({"expires_at": 1893456000}) == 1893456000
+
+
+def test_iso_expires_at_is_parsed():
+    assert parse_expiry({"expires_at": "2030-01-01T00:00:00Z"}) == 1893456000
+
+
+def test_unparseable_expiry_falls_back_conservatively(caplog):
+    got = parse_expiry({"token_type": "Bearer"})
+    assert got == pytest.approx(time.time() + 3600, abs=2)
+    assert "no parseable expiry" in caplog.text  # must not fail silently
+
+
+# --- locking / isolation ---------------------------------------------------
+
+class _FakeSession:
+    """Records the calls refresh_token_locked makes on its own session."""
+
+    def __init__(self, auth, log):
+        self._auth = auth
+        self.log = log
+        self._for_update = False
+
+    def query(self, model):
+        return self
+
+    def filter(self, *args):
+        return self
+
+    def with_for_update(self):
+        self._for_update = True
+        self.log.append("locked")
+        return self
+
+    def first(self):
+        return self._auth
+
+    def commit(self):
+        self.log.append("commit")
+
+    def rollback(self):
+        self.log.append("rollback")
+
+    def close(self):
+        self.log.append("close")
+
+
+@pytest.fixture
+def session_log(monkeypatch):
+    log: list[str] = []
+    holder = {}
+
+    def factory():
+        session = _FakeSession(holder.get("auth"), log)
+        return session
+
+    monkeypatch.setattr(oauth_tokens, "SessionLocal", factory)
+    return log, holder
+
+
+def _auth(expires_at):
+    return SimpleNamespace(
+        expires_at=expires_at, access_token="old", refresh_token="old-refresh"
+    )
+
+
+def test_refresh_takes_a_row_lock_and_commits_on_its_own_session(session_log):
+    log, holder = session_log
+    holder["auth"] = _auth(int(time.time()))  # expired
+    exchanged = TokenSet("new", "new-refresh", 9999999999)
+
+    refresh_token_locked(type("M", (), {"id": 1, "__tablename__": "m"}), lambda _: exchanged, 300)
+
+    # The lock is what stops two callers from both spending the same refresh
+    # token — providers rotate them, so the loser's token is dead for good.
+    assert log == ["locked", "commit", "close"]
+    assert holder["auth"].access_token == "new"
+
+
+def test_a_refresh_already_done_by_another_caller_is_skipped(session_log):
+    log, holder = session_log
+    holder["auth"] = _auth(int(time.time()) + 100_000)  # someone else just refreshed
+
+    def exchange(_):
+        raise AssertionError("must not spend a refresh token that isn't needed")
+
+    refresh_token_locked(type("M", (), {"id": 1, "__tablename__": "m"}), exchange, 300)
+    assert log == ["locked", "close"]  # no commit: nothing to do
+
+
+def test_a_failed_exchange_rolls_back_only_its_own_session(session_log):
+    log, holder = session_log
+    holder["auth"] = _auth(int(time.time()))
+
+    def exchange(_):
+        raise RuntimeError("provider down")
+
+    with pytest.raises(RuntimeError):
+        refresh_token_locked(type("M", (), {"id": 1, "__tablename__": "m"}), exchange, 300)
+
+    # Previously this ran on the caller's session, so the rollback threw away
+    # whatever bulk activity upserts that session had pending.
+    assert log == ["locked", "rollback", "close"]
+
+
+def test_needs_refresh_respects_the_buffer():
+    assert needs_refresh(int(time.time()) + 100, buffer_seconds=300)
+    assert not needs_refresh(int(time.time()) + 1000, buffer_seconds=300)


### PR DESCRIPTION
> **Stacket på #92** (91 → 92 → denne).

Fire defekter, alle duplisert i begge provider-appene. Nå fikset ett sted: `apps/shared/oauth_tokens.py`.

## 1. Refreshen committet på *kallerens* session

`get_valid_token(db)` kalles midt inne i en sync-task som allerede har køet bulk-upserts av aktiviteter på **samme** session.

- Utløste refreshen → `db.commit()` committet en **halvferdig sync**
- Feilet refreshen → `db.rollback()` **kastet de ventende upsertene**

Refreshen kjører nå i sin egen kortlivede session og kan verken committe eller forkaste kallerens arbeid.

## 2. Read-check-refresh uten lås

To kallere (cron-syncen og en manuell `/refresh-data`) kunne begge se et utløpende token og begge bruke **samme** refresh token. Strava og WakaTime *roterer* refresh tokens — så taperens token er permanent dødt, og du må re-autorisere manuelt.

Nå: `SELECT ... FOR UPDATE` + re-sjekk etter at låsen er tatt (double-checked locking), så den andre kalleren finner jobben allerede gjort.

## 3. WakaTime-refresh var beviselig ødelagt

`utils.py` kalte `response.json()` uten fallback — mens appens **egen** OAuth-callback eksplisitt håndterte den form-encodede bodyen WakaTime faktisk returnerer. Refreshen raiset altså hver gang, og integrasjonen døde ~1 time etter hver innlogging. Begge veier deler nå én dekoder.

## 4. Utløpstiden var oppdiktet

```python
elif "expires_at" in token_data:
     # ...hopefully it's consistent.
     # Let's assume standard OAuth 2.0 flow for now
     new_expires_at = current_time + 3600 # Fallback
```

Den leste feltet, kastet verdien, og lagret `now + 3600` uansett. `parse_expiry` håndterer nå `expires_in`, numerisk `expires_at` og ISO-8601 `expires_at` — og **logger høylytt** i stedet for å gjette stille når svaret ikke har noen.

## Ryddet på veien

`is_token_expired` (definert to steder, kalt null steder) er borte, og providerens rå response-body interpoleres ikke lenger inn i exception-meldinger.

## Test

10 nye tester — inkludert at en mislykket refresh **kun** ruller tilbake sin egen session, og at en refresh en annen kaller allerede har gjort hoppes over uten å bruke opp et token.