### PR TITLE
fix(projects): bound the list endpoints and let the DB arbitrate slugs

### DIFF
--- a/apps/projects/main.py
+++ b/apps/projects/main.py
@@ -9,8 +9,9 @@ from uuid import uuid4
 
 import aiofiles
 import filetype
-from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
 from fastapi.responses import FileResponse
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from apps.projects.models import Project
@@ -35,6 +36,12 @@ UPLOAD_DIR = settings.upload_dir
 UPLOAD_BASE_URL = settings.upload_base_url
 ALLOWED_TYPES = {"image/jpeg", "image/png", "image/webp", "image/gif"}
 MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB
+
+# The list endpoints used to end in a bare .all(). The table is small today, but
+# an unbounded query is a latent outage: it grows into one silently, and the
+# strava app already caps its own listing at 200 for exactly this reason.
+DEFAULT_PAGE_SIZE = 50
+MAX_PAGE_SIZE = 200
 
 # Hardened app: CORS, cache-control, security headers, and locally-served docs
 # (matches the other services; a strict CSP would block CDN-hosted Swagger).
@@ -63,27 +70,39 @@ def health():
 
 
 @router.get("", response_model=list[ProjectResponse])
-def list_published_projects(db: Session = Depends(get_db)):
+def list_published_projects(
+    db: Session = Depends(get_db),
+    limit: int = Query(DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
+    offset: int = Query(0, ge=0),
+):
     """
-    List all published projects.
+    List published projects, newest-ordered.
     Sorted by order (ascending), then by created_at (descending).
     """
     projects = (
         db.query(Project)
         .filter(Project.published == True)
         .order_by(Project.order.asc(), Project.created_at.desc())
+        .offset(offset)
+        .limit(limit)
         .all()
     )
     return projects
 
 
 @router.get("/featured", response_model=list[ProjectResponse])
-def list_featured_projects(db: Session = Depends(get_db)):
-    """List all featured projects (for homepage display)."""
+def list_featured_projects(
+    db: Session = Depends(get_db),
+    limit: int = Query(DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
+    offset: int = Query(0, ge=0),
+):
+    """List featured projects (for homepage display)."""
     projects = (
         db.query(Project)
         .filter(Project.published == True, Project.featured == True)
         .order_by(Project.order.asc())
+        .offset(offset)
+        .limit(limit)
         .all()
     )
     return projects
@@ -123,11 +142,15 @@ def get_project(slug: str, db: Session = Depends(get_db)):
 def list_all_projects(
     api_key: str = Depends(get_api_key),
     db: Session = Depends(get_db),
+    limit: int = Query(DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
+    offset: int = Query(0, ge=0),
 ):
-    """List all projects including unpublished (admin only)."""
+    """List projects including unpublished (admin only)."""
     projects = (
         db.query(Project)
         .order_by(Project.order.asc(), Project.created_at.desc())
+        .offset(offset)
+        .limit(limit)
         .all()
     )
     return projects
@@ -153,14 +176,16 @@ def create_project(
     db: Session = Depends(get_db),
 ):
     """Create a new project."""
-    # Check for duplicate slug
-    existing = db.query(Project).filter(Project.slug == project_data.slug).first()
-    if existing:
-        raise HTTPException(status_code=400, detail="Slug already exists")
-
     project = Project(**project_data.model_dump())
     db.add(project)
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        # Let the database's unique constraint be the arbiter instead of a
+        # preceding SELECT: between the check and the insert, a concurrent create
+        # of the same slug slipped through and surfaced as an unhandled 500.
+        db.rollback()
+        raise HTTPException(status_code=400, detail="Slug already exists") from None
     db.refresh(project)
     return project
 
@@ -177,18 +202,17 @@ def update_project(
     if not project:
         raise HTTPException(status_code=404, detail="Project not found")
 
-    # Check for slug conflict if changing slug
-    if project_data.slug and project_data.slug != slug:
-        existing = db.query(Project).filter(Project.slug == project_data.slug).first()
-        if existing:
-            raise HTTPException(status_code=400, detail="Slug already exists")
-
     # Update only provided fields
     update_data = project_data.model_dump(exclude_unset=True)
     for key, value in update_data.items():
         setattr(project, key, value)
 
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        # Same race as create: the unique constraint decides, not a prior SELECT.
+        db.rollback()
+        raise HTTPException(status_code=400, detail="Slug already exists") from None
     db.refresh(project)
     return project
 

--- a/tests/test_projects_pagination.py
+++ b/tests/test_projects_pagination.py
@@ -1,0 +1,75 @@
+"""Projects list endpoints are bounded, and slug uniqueness is decided by the DB.
+
+Both are DB-free: the pagination bounds are rejected during request validation,
+and the slug race is exercised by substituting the session.
+"""
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from starlette.testclient import TestClient
+
+from apps.projects.main import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, app
+from apps.shared.auth import get_api_key
+from apps.shared.database import get_db
+
+client = TestClient(app)
+
+LIST_PATHS = ["/projects", "/projects/featured"]
+
+
+# --- pagination bounds -----------------------------------------------------
+
+@pytest.mark.parametrize("path", LIST_PATHS)
+@pytest.mark.parametrize("query", ["limit=0", f"limit={MAX_PAGE_SIZE + 1}", "offset=-1"])
+def test_out_of_range_paging_is_rejected(path, query):
+    assert client.get(f"{path}?{query}").status_code == 422
+
+
+@pytest.mark.parametrize("path", LIST_PATHS)
+def test_paging_defaults_are_documented(path):
+    schema = app.openapi()["paths"][f"/v1{path}"]["get"]
+    params = {p["name"]: p["schema"] for p in schema["parameters"]}
+    assert params["limit"]["default"] == DEFAULT_PAGE_SIZE
+    assert params["limit"]["maximum"] == MAX_PAGE_SIZE
+
+
+# --- slug race -------------------------------------------------------------
+
+class _ConflictingSession:
+    """A session whose commit loses the race to a concurrent insert."""
+
+    def __init__(self):
+        self.rolled_back = False
+
+    def add(self, obj):
+        pass
+
+    def commit(self):
+        raise IntegrityError("INSERT", {}, Exception("duplicate key value"))
+
+    def rollback(self):
+        self.rolled_back = True
+
+    def refresh(self, obj):
+        raise AssertionError("must not refresh after a failed commit")
+
+
+@pytest.fixture
+def conflicting_db():
+    session = _ConflictingSession()
+    app.dependency_overrides[get_db] = lambda: session
+    app.dependency_overrides[get_api_key] = lambda: "test-key"
+    yield session
+    app.dependency_overrides.clear()
+
+
+def test_duplicate_slug_returns_400_not_500(conflicting_db):
+    # Previously a check-then-insert: between the SELECT and the INSERT a
+    # concurrent create of the same slug slipped through as an unhandled 500.
+    resp = client.post(
+        "/projects",
+        json={"title": "T", "slug": "taken", "description": "d"},
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "Slug already exists"
+    assert conflicting_db.rolled_back


### PR DESCRIPTION
Uavhengig av de andre PR-ene — kan merges når som helst.

## 1. Ubegrensede queries

`list_published_projects`, `list_featured_projects` og `list_all_projects` endte alle i en naken `.all()`. Tabellen er liten i dag, så dette er en **latent** utfall, ikke et aktivt — den vokser stille inn i det. Strava-appen capper allerede sin egen listing på 200 av nøyaktig denne grunnen.

Alle tre tar nå `limit`/`offset`, default 50, maks 200.

## 2. Slug check-then-insert race

```python
existing = db.query(Project).filter(Project.slug == slug).first()   # ← SELECT
if existing: raise HTTPException(400, ...)
db.add(project); db.commit()                                        # ← INSERT
```

To samtidige `create` med samme slug passerer begge sjekken; den andre treffer unique-constrainten og kom ut som en **uhåndtert 500** — der APIet dokumenterer 400. Dette er akkurat mønsteret `apps/shared/upsert.py` ble skrevet for å fjerne.

Nå får databasen bestemme: insert forsøkes, `IntegrityError` oversettes til 400. `update_project` hadde samme race.

## Test

9 tester, alle DB-frie: paging-grensene avvises i request-validering, og racet trigges ved å bytte ut sessionen.