### PR TITLE
feat(strava): aggregated heatmap endpoint with home-area clipping

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,25 @@ STRAVA_CLIENT_SECRET=<your_client_secret_from_strava>
 # Local dev:  http://localhost:5001/strava/callback
 STRAVA_REDIRECT_URI=https://api.yourdomain.com/strava/callback
 
+# ----------------------------------------------------------------
+# Heatmap privacy clipping (REQUIRED for /strava/heatmap)
+# ----------------------------------------------------------------
+# /strava/heatmap publishes where you run. Everything within
+# STRAVA_PRIVACY_RADIUS_M of the coordinate below is removed from
+# every track before aggregation, so the map never reveals your
+# address or when you are away from it.
+#
+# Set this to your home coordinate (decimal degrees, WGS84). The
+# values below are Oslo city centre, i.e. a placeholder -- they are
+# NOT a sensible default to ship with.
+#
+# Without both LAT and LNG the endpoint returns 503 and serves
+# nothing. That is deliberate: missing config must never quietly
+# degrade into missing privacy.
+STRAVA_HOME_LAT=59.9139
+STRAVA_HOME_LNG=10.7522
+STRAVA_PRIVACY_RADIUS_M=500
+
 # ================================================================
 # Frontend Integration (Optional)
 # ================================================================

--- a/alembic/versions/9c4e1b7a2f30_add_strava_route_polyline.py
+++ b/alembic/versions/9c4e1b7a2f30_add_strava_route_polyline.py
@@ -1,0 +1,37 @@
+"""add strava route polyline
+
+Adds the raw route geometry Strava already returns with every activity in the
+list response — no extra API calls needed to populate it. Nullable, so the
+column lands on existing rows without a table rewrite; those rows stay NULL
+until a full re-sync (`POST /strava/refresh-data?full=true`) backfills them,
+which is a prerequisite for /strava/heatmap returning anything.
+
+Revision ID: 9c4e1b7a2f30
+Revises: 56883c337dbe
+Create Date: 2026-07-25 10:12:00.000000
+
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = '9c4e1b7a2f30'
+down_revision: str | Sequence[str] | None = '56883c337dbe'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        'strava_activities',
+        sa.Column('summary_polyline', sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('strava_activities', 'summary_polyline')

--- a/apps/shared/app_factory.py
+++ b/apps/shared/app_factory.py
@@ -10,6 +10,7 @@ the security hardening can never silently drift between apps.
 """
 
 from fastapi import APIRouter, FastAPI
+from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.openapi.docs import get_swagger_ui_oauth2_redirect_html
 from fastapi.staticfiles import StaticFiles
 
@@ -66,6 +67,14 @@ def create_app(
     app.add_middleware(
         BodySizeLimitMiddleware, max_bytes=settings.max_request_body_bytes
     )
+
+    # Compress responses here rather than relying on the reverse proxy: Caddy
+    # doesn't compress unless explicitly told to, and that config lives outside
+    # this repo. The route-geometry endpoint is ~1.3 MB uncompressed and ~230 KB
+    # gzipped, which is the difference between comfortably meeting the frontend's
+    # 5 s budget on mobile and not. The threshold keeps small JSON responses
+    # untouched, where compression would cost more than it saves.
+    app.add_middleware(GZipMiddleware, minimum_size=1024)
 
     # Serve Swagger UI assets locally (no third-party CDN) so the strict CSP applies.
     app.mount("/static", StaticFiles(directory="static"), name="static")

--- a/apps/shared/config.py
+++ b/apps/shared/config.py
@@ -9,6 +9,7 @@ config lives in one typed place.
 
 from functools import lru_cache
 
+from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -53,6 +54,20 @@ class Settings(BaseSettings):
     strava_redirect_uri: str | None = None
     strava_owner_athlete_id: str | None = None
 
+    # Strava heatmap privacy.
+    #
+    # Route tracks are absolute WGS84 and end up on a public page, so everything
+    # within `strava_privacy_radius_m` of the home coordinate is clipped out of
+    # every track before it is aggregated. Both values live here and are never
+    # echoed in any response — publishing the radius would let a caller
+    # triangulate the centre it was measured from.
+    #
+    # No default coordinate exists on purpose: /strava/heatmap refuses to serve
+    # (503) rather than emit unclipped tracks if this is unconfigured.
+    strava_home_lat: float | None = None
+    strava_home_lng: float | None = None
+    strava_privacy_radius_m: float = 500.0
+
     # WakaTime OAuth (same ownership rule as Strava above).
     wakatime_client_id: str | None = None
     wakatime_client_secret: str | None = None
@@ -79,9 +94,44 @@ class Settings(BaseSettings):
     # this at an HTTPS provider to stop leaking visitor IPs in the clear.
     geo_lookup_url: str = "http://ip-api.com/json/{ip}"
 
+    @field_validator("strava_home_lat")
+    @classmethod
+    def _check_lat(cls, v: float | None) -> float | None:
+        if v is not None and not -90.0 <= v <= 90.0:
+            raise ValueError("STRAVA_HOME_LAT must be between -90 and 90")
+        return v
+
+    @field_validator("strava_home_lng")
+    @classmethod
+    def _check_lng(cls, v: float | None) -> float | None:
+        if v is not None and not -180.0 <= v <= 180.0:
+            raise ValueError("STRAVA_HOME_LNG must be between -180 and 180")
+        return v
+
+    @field_validator("strava_privacy_radius_m")
+    @classmethod
+    def _check_radius(cls, v: float) -> float:
+        # A zero or negative radius would silently disable the clipping that the
+        # whole feature depends on, so it's a startup error rather than a no-op.
+        if v <= 0:
+            raise ValueError("STRAVA_PRIVACY_RADIUS_M must be greater than 0")
+        return v
+
     @property
     def is_production(self) -> bool:
         return self.environment == "production"
+
+    @property
+    def strava_home_coordinate(self) -> tuple[float, float] | None:
+        """Home ``(lat, lng)``, or None when the pair isn't fully configured.
+
+        Both halves are required: a latitude without a longitude is a
+        misconfiguration, and treating it as "partially set" would be the one
+        way untrimmed tracks could slip out.
+        """
+        if self.strava_home_lat is None or self.strava_home_lng is None:
+            return None
+        return (self.strava_home_lat, self.strava_home_lng)
 
     @property
     def excluded_visit_ips(self) -> set[str]:

--- a/apps/strava/client.py
+++ b/apps/strava/client.py
@@ -11,6 +11,22 @@ from apps.strava.client_factory import strava_client
 from apps.strava.utils import get_valid_token
 
 
+def _summary_polyline(activity) -> str | None:
+    """Pull the route polyline off a SummaryActivity, if it has one.
+
+    Strava includes this in the *list* response, so no extra request per
+    activity is needed — important, because the API allows only 100 calls per
+    15 minutes and a per-activity fetch would blow through that on one sync.
+
+    Activities recorded without GPS (treadmill) come back with the map present
+    but the polyline empty; normalise that to None.
+    """
+    activity_map = getattr(activity, "map", None)
+    if activity_map is None:
+        return None
+    return getattr(activity_map, "summary_polyline", None) or None
+
+
 def get_ytd_stats(db: Session) -> dict[str, dict[str, Any]]:
     """
     Fetch year-to-date statistics from Strava.
@@ -129,6 +145,7 @@ def get_all_activities(db: Session, limit: int = None, after=None):
     activities = client.get_activities(limit=limit, after=after)
 
     for activity in activities:
+        polyline = _summary_polyline(activity)
         yield {
             "id": activity.id,
             "name": activity.name,
@@ -144,5 +161,6 @@ def get_all_activities(db: Session, limit: int = None, after=None):
             "max_speed": float(activity.max_speed) if activity.max_speed else 0.0,
             "average_heartrate": float(activity.average_heartrate) if hasattr(activity, 'average_heartrate') and activity.average_heartrate else None,
             "max_heartrate": float(activity.max_heartrate) if hasattr(activity, 'max_heartrate') and activity.max_heartrate else None,
-            "kudos_count": int(activity.kudos_count) if hasattr(activity, 'kudos_count') else 0
+            "kudos_count": int(activity.kudos_count) if hasattr(activity, 'kudos_count') else 0,
+            "summary_polyline": polyline,
         }

--- a/apps/strava/geometry.py
+++ b/apps/strava/geometry.py
@@ -1,0 +1,258 @@
+"""Route geometry: encoded polylines -> a privacy-safe, aggregated heat grid.
+
+Strava ships ``SummaryActivity.map.summary_polyline`` in the *list* response, so
+the route shapes come for free with the activity sync — no per-activity detail
+call, no N+1 against the 100-req/15-min rate limit.
+
+Those tracks are absolute WGS84 and are destined for a public page, so two
+things happen before anything is served:
+
+1. ``clip_home_area`` removes everything within a configured radius of home. A
+   start point at the door reveals a home address and, with timestamps, when
+   nobody is in. Strava's own privacy zones do not necessarily apply to what you
+   fetch with your own token, so the clipping happens here.
+2. ``build_heatmap`` collapses what's left into counts on a coarse grid. The
+   output has no timestamps, no activity IDs, and no ordering — individual runs
+   cannot be reconstructed from it, only the aggregate shape of where the
+   running happens.
+
+Both take the home coordinate and radius as required arguments rather than
+reading config themselves: it keeps them pure and testable, and forces every
+caller to make a deliberate decision about where home is.
+"""
+
+import logging
+import math
+
+logger = logging.getLogger(__name__)
+
+# Google encoded-polyline precision used by Strava.
+POLYLINE_PRECISION = 5
+
+# Heat grid resolution. 15 m is about the width of a road, which is the scale at
+# which "I run here often" is meaningful — finer just splits one path across
+# several cells and multiplies the payload.
+HEATMAP_CELL_SIZE_M = 15.0
+
+# Decimal places on the emitted cell coordinates. At 4 places a degree of
+# latitude resolves to ~11 m, i.e. finer than the cell itself, so this rounding
+# never merges cells that the grid meant to keep apart — and it keeps the JSON
+# roughly half the size of full float output.
+CELL_COORD_PRECISION = 4
+
+# Metres per degree of latitude (mean value). Accurate to ~0.5% anywhere on
+# Earth, far inside the tolerance of both the privacy radius and a 15 m cell;
+# longitude is additionally scaled by cos(latitude).
+METERS_PER_DEGREE_LAT = 111_320.0
+
+# A varint in this encoding is at most 6 groups of 5 bits. Anything longer is
+# malformed input, not a huge number — bail instead of looping.
+_MAX_VARINT_SHIFT = 30
+
+
+def decode_polyline(encoded: str, precision: int = POLYLINE_PRECISION) -> list[tuple[float, float]]:
+    """Decode a Google encoded polyline into ``(lat, lng)`` pairs.
+
+    Implemented here rather than pulled in as a dependency: it is ~30 lines of a
+    frozen, fully specified format, and this way the input validation is ours.
+
+    Raises:
+        ValueError: the string is truncated, contains characters outside the
+            encoding's range, or yields coordinates off the globe.
+    """
+    factor = 10**precision
+    length = len(encoded)
+    index = 0
+    lat = 0
+    lng = 0
+    coords: list[tuple[float, float]] = []
+
+    while index < length:
+        deltas = []
+        for _ in range(2):  # latitude delta, then longitude delta
+            result = 0
+            shift = 0
+            while True:
+                if index >= length:
+                    raise ValueError("truncated polyline: varint ends mid-sequence")
+                byte = ord(encoded[index]) - 63
+                index += 1
+                # The format only uses ASCII 63..126, i.e. 0..0x3F after the
+                # offset. Anything higher would silently contribute junk bits
+                # and decode into a plausible-looking but fabricated route.
+                if not 0 <= byte <= 0x3F:
+                    raise ValueError("invalid character in polyline")
+                result |= (byte & 0x1F) << shift
+                shift += 5
+                if byte < 0x20:
+                    break
+                if shift > _MAX_VARINT_SHIFT:
+                    raise ValueError("malformed polyline: varint too long")
+            # Low bit is the sign flag; the value is zigzag-encoded.
+            deltas.append(~(result >> 1) if result & 1 else (result >> 1))
+
+        lat += deltas[0]
+        lng += deltas[1]
+        point = (lat / factor, lng / factor)
+        if not (-90.0 <= point[0] <= 90.0 and -180.0 <= point[1] <= 180.0):
+            raise ValueError("polyline decodes to coordinates off the globe")
+        coords.append(point)
+
+    return coords
+
+
+def _distance_m(lat: float, lng: float, home: tuple[float, float], lng_scale: float) -> float:
+    """Metres from ``home``, using an equirectangular approximation.
+
+    At a few-hundred-metre scale the error versus haversine is centimetres, and
+    it avoids a trig call per point. The longitude difference is wrapped into
+    [-180, 180) so a home near the antimeridian doesn't read as ~360° away from
+    a point just across it — which would keep an in-radius point.
+    """
+    home_lat, home_lng = home
+    dy = (lat - home_lat) * METERS_PER_DEGREE_LAT
+    dx = ((lng - home_lng + 180.0) % 360.0 - 180.0) * lng_scale
+    return math.hypot(dx, dy)
+
+
+def clip_home_area(
+    points: list[tuple[float, float]],
+    home: tuple[float, float],
+    radius_m: float,
+) -> list[tuple[float, float]]:
+    """Drop every point within ``radius_m`` of ``home``.
+
+    Every point inside the radius goes, not just the leading and trailing ones.
+    A run that happens to pass the house mid-route would otherwise leak the exact
+    address from the middle of the track, which defeats the purpose of clipping
+    the ends at all.
+
+    Unlike a route being drawn as a line, the heat grid has no connectivity to
+    preserve — the points are about to become unordered cell counts — so the
+    surviving points are simply returned as-is. Nothing is interpolated across
+    the excluded area, and no line is drawn through it.
+
+    Returns an empty list when the whole route sits inside the radius, e.g. a
+    short loop around the block.
+    """
+    if radius_m <= 0:
+        raise ValueError("radius_m must be greater than 0")
+
+    lng_scale = METERS_PER_DEGREE_LAT * math.cos(math.radians(home[0]))
+    return [(lat, lng) for lat, lng in points if _distance_m(lat, lng, home, lng_scale) > radius_m]
+
+
+def grid_steps(cell_size_m: float, reference_lat: float) -> tuple[float, float]:
+    """Degree-sized grid steps for roughly square ``cell_size_m`` cells.
+
+    Longitude degrees shrink toward the poles, so the east-west step is scaled by
+    cos(latitude) — at 60°N a degree of longitude is half a degree of latitude,
+    and skipping this would make every cell twice as wide as it is tall.
+
+    A single reference latitude is used for the whole grid rather than each
+    point's own, so the grid stays uniform and a point can't land in two
+    different cells depending on rounding order.
+    """
+    if cell_size_m <= 0:
+        raise ValueError("cell_size_m must be greater than 0")
+    lat_step = cell_size_m / METERS_PER_DEGREE_LAT
+    lng_step = cell_size_m / (METERS_PER_DEGREE_LAT * math.cos(math.radians(reference_lat)))
+    return lat_step, lng_step
+
+
+def track_cells(
+    points: list[tuple[float, float]],
+    lat_step: float,
+    lng_step: float,
+) -> set[tuple[float, float]]:
+    """Snap a track's points to grid cells, returning the distinct ``(lng, lat)`` centres.
+
+    Deduplicated *within* the track on purpose: a cell is counted once per
+    activity, not once per GPS sample. Sampling density varies with pace, so
+    counting raw samples would light up the places you run slowest rather than
+    the places you run often — and it would encode a lingering signal, which is
+    exactly the kind of detail this aggregate is meant to drop.
+
+    Coordinates are rounded to the emitted precision here rather than at
+    serialization time, so cells that round together are merged into one entry
+    instead of appearing twice with split counts.
+    """
+    cells = set()
+    for lat, lng in points:
+        cell_lat = round(round(lat / lat_step) * lat_step, CELL_COORD_PRECISION)
+        cell_lng = round(round(lng / lng_step) * lng_step, CELL_COORD_PRECISION)
+        cells.add((cell_lng, cell_lat))
+    return cells
+
+
+def build_heatmap(
+    polylines: list[str | None],
+    home: tuple[float, float],
+    radius_m: float,
+    cell_size_m: float = HEATMAP_CELL_SIZE_M,
+) -> dict:
+    """Aggregate encoded polylines into ``{cells, bounds, max_count, gps_activity_count}``.
+
+    ``cells`` is a list of ``[lng, lat, count]`` triples — arrays rather than
+    objects, which drops the repeated key names that would otherwise dominate the
+    payload — sorted for a deterministic response (which also compresses better,
+    since neighbouring cells share coordinate prefixes).
+
+    ``count`` is the number of *activities* that touched the cell.
+
+    ``bounds`` is ``[min_lng, min_lat, max_lng, max_lat]``, or None when nothing
+    survived. A polyline that fails to decode is logged and skipped: one corrupt
+    activity must not fail the whole aggregate.
+    """
+    lat_step, lng_step = grid_steps(cell_size_m, home[0])
+    lng_scale = METERS_PER_DEGREE_LAT * math.cos(math.radians(home[0]))
+
+    # Clipping removes *points* inside the radius, but snapping then moves each
+    # survivor up to half a cell diagonal — so a point legally 501 m out can
+    # produce a cell centred at 490 m, publishing a corner of the excluded area.
+    # Cells are therefore re-checked against the radius plus the cell's own
+    # reach, which guarantees no emitted cell even overlaps the exclusion circle.
+    cell_reach_m = cell_size_m * math.sqrt(2) / 2
+    min_cell_distance_m = radius_m + cell_reach_m
+
+    counts: dict[tuple[float, float], int] = {}
+    gps_activity_count = 0
+
+    for encoded in polylines:
+        if not encoded:
+            continue  # recorded without GPS (treadmill)
+        try:
+            coords = decode_polyline(encoded)
+        except ValueError as exc:
+            logger.warning("Skipping unparseable route polyline: %s", exc)
+            continue
+
+        kept = clip_home_area(coords, home, radius_m)
+        if not kept:
+            continue  # never left the privacy radius
+
+        cells = {
+            (lng, lat)
+            for lng, lat in track_cells(kept, lat_step, lng_step)
+            if _distance_m(lat, lng, home, lng_scale) >= min_cell_distance_m
+        }
+        if not cells:
+            continue
+
+        gps_activity_count += 1
+        for cell in cells:
+            counts[cell] = counts.get(cell, 0) + 1
+
+    if not counts:
+        return {"cells": [], "bounds": None, "max_count": 0, "gps_activity_count": 0}
+
+    cells = [[lng, lat, count] for (lng, lat), count in sorted(counts.items())]
+    lngs = [c[0] for c in cells]
+    lats = [c[1] for c in cells]
+
+    return {
+        "cells": cells,
+        "bounds": [min(lngs), min(lats), max(lngs), max(lats)],
+        "max_count": max(counts.values()),
+        "gps_activity_count": gps_activity_count,
+    }

--- a/apps/strava/main.py
+++ b/apps/strava/main.py
@@ -5,12 +5,18 @@ OAuth integration for Strava with cached statistics.
 Single user mode - stores one set of tokens and serves cached data.
 """
 
+import hashlib
+import hmac
 import logging
+import secrets
+from collections import OrderedDict
 from datetime import datetime
+from threading import Lock
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
-from fastapi.responses import FileResponse, RedirectResponse
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request, Response
+from fastapi.responses import FileResponse, JSONResponse, RedirectResponse
 from sqlalchemy import desc, extract, func
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from apps.shared.app_factory import create_app, include_versioned
@@ -21,10 +27,59 @@ from apps.shared.errors import log_and_sanitize_error
 from apps.shared.oauth_owner import enforce_owner
 from apps.shared.oauth_state import generate_state, validate_state
 from apps.strava.client_factory import strava_client
+from apps.strava.geometry import HEATMAP_CELL_SIZE_M, build_heatmap
 from apps.strava.models import StravaActivity, StravaAuth, StravaStats
 from apps.strava.tasks import fetch_and_cache_stats
 
 logger = logging.getLogger(__name__)
+
+# Bump when the shape or the derivation of /strava/heatmap changes, so every
+# cached copy revalidates instead of serving a grid built by older rules.
+HEATMAP_PAYLOAD_VERSION = "1"
+
+# Cached hard, because the aggregate is almost entirely immutable: a finished
+# run's track never changes, so only a newly logged activity can move it, and
+# that just adds counts. An hour of staleness on the newest run is a fair price
+# for the frontend usually paying nothing at all. `stale-while-revalidate` then
+# lets a shared cache serve the old copy instantly while it refreshes in the
+# background, so even revalidation never lands in the client's 5 s budget.
+HEATMAP_CACHE_CONTROL = "public, max-age=3600, stale-while-revalidate=86400"
+
+# ETag key. The tag commits to the home coordinate and privacy radius so a config
+# change invalidates every cached response — but those are low-entropy values, and
+# a plain digest of them could be brute-forced back out of a public header. Keying
+# the digest with a server secret makes that impossible. Falls back to a
+# per-process random key when no secret is configured: ETags then reset on
+# restart, which costs a revalidation and leaks nothing.
+_ETAG_KEY = (settings.state_secret or secrets.token_urlsafe(32)).encode()
+
+# Aggregating every track is the one genuinely expensive thing this service
+# does, and the ETag already captures exactly what the result depends on — so it
+# doubles as the cache key: if the tag matches, the cached body is valid by
+# construction. A handful of entries covers the realistic query variants
+# (all types, Run, Ride) across a config change.
+#
+# A lock rather than a bare dict because sync endpoints run in a threadpool and
+# OrderedDict.move_to_end is not atomic.
+_HEATMAP_CACHE: OrderedDict[str, dict] = OrderedDict()
+_HEATMAP_CACHE_MAX = 8
+_HEATMAP_CACHE_LOCK = Lock()
+
+
+def _heatmap_cache_get(etag: str) -> dict | None:
+    with _HEATMAP_CACHE_LOCK:
+        payload = _HEATMAP_CACHE.get(etag)
+        if payload is not None:
+            _HEATMAP_CACHE.move_to_end(etag)
+        return payload
+
+
+def _heatmap_cache_put(etag: str, payload: dict) -> None:
+    with _HEATMAP_CACHE_LOCK:
+        _HEATMAP_CACHE[etag] = payload
+        _HEATMAP_CACHE.move_to_end(etag)
+        while len(_HEATMAP_CACHE) > _HEATMAP_CACHE_MAX:
+            _HEATMAP_CACHE.popitem(last=False)
 
 # Schema is managed by Alembic migrations (`alembic upgrade head`), not created
 # at import time. See alembic/ and `make migrate`.
@@ -391,6 +446,156 @@ def get_all_activities_endpoint(
         "offset": offset,
         "data": [a.to_dict() for a in activities],
     }
+
+
+def _weak_etag(*parts: object) -> str:
+    """Build a weak, secret-keyed ETag from the values a response depends on.
+
+    Weak (`W/`) because gzip means the same resource ships as more than one byte
+    sequence; a strong tag is supposed to identify exact bytes. Weak is what
+    cache revalidation needs anyway — it asserts semantic equivalence.
+    """
+    payload = "|".join(str(p) for p in parts).encode()
+    digest = hmac.new(_ETAG_KEY, payload, hashlib.sha256).hexdigest()[:32]
+    return f'W/"{digest}"'
+
+
+def _strip_weak(tag: str) -> str:
+    return tag[2:] if tag.startswith("W/") else tag
+
+
+def _etag_matches(if_none_match: str | None, etag: str) -> bool:
+    """RFC 9110 If-None-Match check: comma-separated list, `*`, weak `W/` prefix.
+
+    Both sides are normalised — comparing a `W/`-prefixed tag against stripped
+    candidates would never match, and the endpoint would answer 200 forever.
+    """
+    if not if_none_match:
+        return False
+    candidates = [c.strip() for c in if_none_match.split(",")]
+    if "*" in candidates:
+        return True
+    return _strip_weak(etag) in {_strip_weak(c) for c in candidates}
+
+
+@router.get("/heatmap")
+def get_heatmap(
+    request: Request,
+    activity_type: str | None = Query(None, max_length=50, description="e.g. Run; omit for all types."),
+    db: Session = Depends(get_db),
+):
+    """Aggregated heat grid over every GPS-recorded activity, all years.
+
+    Returns:
+
+        {
+          "cell_size_m": 15,
+          "bounds": [min_lng, min_lat, max_lng, max_lat],   // null when empty
+          "max_count": 87,
+          "activity_count": 512,
+          "total_distance_m": 4210000,
+          "cells": [[lng, lat, count], ...]
+        }
+
+    `cells` are `[lng, lat, count]` triples rather than objects — with hundreds
+    of thousands of cells, repeated key names would dominate the payload. Four
+    decimals resolve to ~11 m, finer than the 15 m cell.
+
+    `count` is how many *activities* touched a cell, not how many GPS samples
+    landed in it. Sample density tracks pace, so counting samples would highlight
+    where the running is slowest rather than where it is most frequent.
+
+    `activity_count` and `total_distance_m` describe every activity matching the
+    filter, including ones without GPS; the cells necessarily derive only from
+    the subset that has a track.
+
+    Privacy: each track is clipped against the configured home coordinate before
+    aggregation (apps/strava/geometry.clip_home_area), and the aggregate itself
+    carries no timestamps, activity IDs, or point ordering — individual runs
+    cannot be reconstructed from it. Neither the home coordinate nor the radius
+    appears in the response. If the coordinate is unconfigured this returns 503
+    rather than aggregate unclipped tracks: absence of config must never degrade
+    into absence of privacy.
+
+    Status codes are meaningful: 200 with `cells: []` means the filter matched
+    nothing (or nothing had GPS), while 503 means nothing has been synced yet,
+    the database is unreachable, or the privacy clipping is unconfigured.
+    """
+    home = settings.strava_home_coordinate
+    if home is None:
+        logger.error(
+            "Refusing to serve heatmap: STRAVA_HOME_LAT/STRAVA_HOME_LNG are not configured"
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="Heatmap is unavailable: privacy clipping is not configured.",
+        )
+    radius_m = settings.strava_privacy_radius_m
+
+    try:
+        query = db.query(StravaActivity)
+        if activity_type:
+            query = query.filter(StravaActivity.type == activity_type)
+
+        # One pass for the summary figures and the cache validator.
+        # `max(fetched_at)` over the filtered set changes exactly when one of
+        # these rows is re-synced, which is the only way the aggregate can move.
+        activity_count, total_distance, last_synced = query.with_entities(
+            func.count(StravaActivity.id),
+            func.coalesce(func.sum(StravaActivity.distance), 0.0),
+            func.max(StravaActivity.fetched_at),
+        ).one()
+
+        if activity_count == 0 and db.query(StravaActivity.id).first() is None:
+            raise HTTPException(
+                status_code=503,
+                detail="Activity data has not been synced yet. Try again shortly.",
+            )
+
+        etag = _weak_etag(
+            HEATMAP_PAYLOAD_VERSION,
+            activity_type,
+            HEATMAP_CELL_SIZE_M,
+            home[0],
+            home[1],
+            radius_m,
+            activity_count,
+            total_distance,
+            last_synced,
+        )
+        headers = {"ETag": etag, "Cache-Control": HEATMAP_CACHE_CONTROL}
+
+        if _etag_matches(request.headers.get("if-none-match"), etag):
+            return Response(status_code=304, headers=headers)
+
+        cached = _heatmap_cache_get(etag)
+        if cached is not None:
+            return JSONResponse(content=cached, headers=headers)
+
+        # Only the polyline column — the rest of the row is dead weight when
+        # hundreds of activities are being aggregated.
+        polylines = [row[0] for row in query.with_entities(StravaActivity.summary_polyline).all()]
+    except SQLAlchemyError as e:
+        sanitized_msg, _ = log_and_sanitize_error(
+            e, "Heatmap query", "Heatmap is temporarily unavailable"
+        )
+        raise HTTPException(status_code=503, detail=sanitized_msg)
+
+    grid = build_heatmap(polylines, home, radius_m)
+    payload = {
+        "cell_size_m": HEATMAP_CELL_SIZE_M,
+        "bounds": grid["bounds"],
+        "max_count": grid["max_count"],
+        "activity_count": activity_count,
+        "total_distance_m": round(float(total_distance)),
+        "cells": grid["cells"],
+    }
+    _heatmap_cache_put(etag, payload)
+
+    # No response_model: pydantic would re-validate hundreds of thousands of
+    # numbers per request for no gain. The shape is built in one place here and
+    # covered by tests instead.
+    return JSONResponse(content=payload, headers=headers)
 
 
 @router.post("/refresh-data")

--- a/apps/strava/models.py
+++ b/apps/strava/models.py
@@ -2,7 +2,7 @@
 Strava database models for OAuth tokens and cached statistics
 """
 from cryptography.fernet import InvalidToken
-from sqlalchemy import JSON, BigInteger, Column, DateTime, Float, Integer, String, func
+from sqlalchemy import JSON, BigInteger, Column, DateTime, Float, Integer, String, Text, func
 
 from apps.shared.database import Base
 from apps.shared.encryption import decrypt_token, encrypt_token
@@ -105,7 +105,17 @@ class StravaActivity(Base):
     average_heartrate = Column(Float, nullable=True)
     max_heartrate = Column(Float, nullable=True)
     kudos_count = Column(Integer, default=0)
-    
+
+    # Raw absolute WGS84 route, exactly as Strava sends it in the activity list.
+    # NULL for activities recorded without GPS (treadmill).
+    #
+    # Stored raw and aggregated on the way out: the home coordinate and privacy
+    # radius live in config and must be changeable without a re-sync, so
+    # /strava/heatmap derives its grid per request. This column is the untrimmed
+    # original and is deliberately absent from `to_dict` — it must never reach a
+    # client.
+    summary_polyline = Column(Text, nullable=True)
+
     # Metadata
     fetched_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 

--- a/tests/test_strava_heatmap.py
+++ b/tests/test_strava_heatmap.py
@@ -1,0 +1,566 @@
+"""Heatmap aggregation: polyline decoding, home clipping, gridding, and /strava/heatmap.
+
+The clipping and aggregation tests are the important ones — they are what stands
+between the home address and a public page.
+"""
+
+import gzip
+import math
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+from starlette.testclient import TestClient
+
+from apps.shared.config import settings
+from apps.shared.database import get_db
+from apps.strava.geometry import (
+    CELL_COORD_PRECISION,
+    HEATMAP_CELL_SIZE_M,
+    METERS_PER_DEGREE_LAT,
+    build_heatmap,
+    clip_home_area,
+    decode_polyline,
+    grid_steps,
+    track_cells,
+)
+from apps.strava.main import _strip_weak, app
+
+# Google's documented reference polyline; decodes to three known coordinates.
+REFERENCE_POLYLINE = "_p~iF~ps|U_ulLnnqC_mqNvxq`@"
+REFERENCE_COORDS = [(38.5, -120.2), (40.7, -120.95), (43.252, -126.453)]
+
+HOME = (59.9139, 10.7522)
+
+
+def _encode(coords, precision=5):
+    """Minimal polyline encoder — test-side only, for building fixtures.
+
+    Deliberately not imported from the app: production only ever decodes, and a
+    shared implementation would let a codec bug cancel itself out in these tests.
+    """
+    factor = 10**precision
+    out = []
+    prev_lat = prev_lng = 0
+    for lat, lng in coords:
+        ilat, ilng = round(lat * factor), round(lng * factor)
+        for delta in (ilat - prev_lat, ilng - prev_lng):
+            v = ~(delta << 1) if delta < 0 else (delta << 1)
+            while v >= 0x20:
+                out.append(chr((0x20 | (v & 0x1F)) + 63))
+                v >>= 5
+            out.append(chr(v + 63))
+        prev_lat, prev_lng = ilat, ilng
+    return "".join(out)
+
+
+def _offset_point(home, north_m=0.0, east_m=0.0):
+    """A coordinate a given number of metres from `home` (flat-earth is fine here)."""
+    lat = home[0] + north_m / METERS_PER_DEGREE_LAT
+    lng = home[1] + east_m / (METERS_PER_DEGREE_LAT * math.cos(math.radians(home[0])))
+    return (lat, lng)
+
+
+def _metres_from_home(lat, lng):
+    dy = (lat - HOME[0]) * METERS_PER_DEGREE_LAT
+    dx = (lng - HOME[1]) * METERS_PER_DEGREE_LAT * math.cos(math.radians(HOME[0]))
+    return math.hypot(dx, dy)
+
+
+# --- polyline decoding ------------------------------------------------------
+
+
+def test_decode_matches_reference_polyline():
+    decoded = decode_polyline(REFERENCE_POLYLINE)
+    assert len(decoded) == 3
+    for got, want in zip(decoded, REFERENCE_COORDS, strict=True):
+        assert got[0] == pytest.approx(want[0], abs=1e-5)
+        assert got[1] == pytest.approx(want[1], abs=1e-5)
+
+
+@pytest.mark.parametrize("bad", ["_p~iF~ps|U_ulL", "\x00\x01", "~~~~~~~~~~~~"])
+def test_decode_rejects_malformed_input(bad):
+    with pytest.raises(ValueError):
+        decode_polyline(bad)
+
+
+@pytest.mark.parametrize("char", ["ÿ", "", "€"])
+def test_decode_rejects_characters_above_the_encoding_range(char):
+    # The format only uses ASCII 63..126. Higher code points used to slip past
+    # the sign check and contribute junk bits, decoding into a plausible-looking
+    # but entirely fabricated route.
+    with pytest.raises(ValueError):
+        decode_polyline(REFERENCE_POLYLINE + char)
+
+
+# --- extraction from Strava's own models ------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ({"map": {"id": "a", "summary_polyline": REFERENCE_POLYLINE}}, REFERENCE_POLYLINE),
+        ({"map": {"id": "a", "summary_polyline": ""}}, None),  # treadmill: no GPS
+        ({}, None),                                            # manual entry: no map at all
+    ],
+)
+def test_polyline_is_read_off_the_list_response(payload, expected):
+    # Validated against a real stravalib SummaryActivity, not a stub: this is the
+    # seam a stravalib upgrade could rename underneath us, and the failure mode
+    # would be silent (an empty heatmap) rather than an exception.
+    from stravalib.model import SummaryActivity
+
+    from apps.strava.client import _summary_polyline
+
+    activity = SummaryActivity.model_validate({"id": 1, "name": "Run", **payload})
+    assert _summary_polyline(activity) == expected
+
+
+# --- clipping (privacy-critical) --------------------------------------------
+
+
+def test_clips_points_inside_radius_at_both_ends():
+    track = [
+        _offset_point(HOME, north_m=0),      # at home
+        _offset_point(HOME, north_m=200),    # inside 500 m
+        _offset_point(HOME, north_m=900),    # outside
+        _offset_point(HOME, north_m=1500),   # outside
+        _offset_point(HOME, north_m=300),    # inside again, on the way back
+    ]
+    assert clip_home_area(track, HOME, 500.0) == track[2:4]
+
+
+def test_clips_points_that_pass_home_mid_route():
+    # A run that goes out, past the house, and out again. The middle points must
+    # go too — leaving them would expose the address just as plainly as the ends.
+    track = [
+        _offset_point(HOME, north_m=2000),
+        _offset_point(HOME, north_m=100),    # inside
+        _offset_point(HOME, north_m=-2000),
+    ]
+    kept = clip_home_area(track, HOME, 500.0)
+    assert kept == [track[0], track[2]]
+
+
+def test_clipping_is_radial_not_just_north_south():
+    # An east-west run past the door must be clipped too; a latitude-only check
+    # would sail straight through.
+    track = [_offset_point(HOME, east_m=d) for d in (0, 100, 300, 900)]
+    kept = clip_home_area(track, HOME, 500.0)
+    assert len(kept) == 1
+    assert _metres_from_home(*kept[0]) > 500.0
+
+
+def test_route_entirely_inside_radius_yields_no_points():
+    track = [_offset_point(HOME, north_m=d) for d in (0, 100, 200, 100, 0)]
+    assert clip_home_area(track, HOME, 500.0) == []
+
+
+def test_radius_is_honoured():
+    track = [_offset_point(HOME, north_m=d) for d in (0, 700, 1400)]
+    assert len(clip_home_area(track, HOME, 500.0)) == 2   # only the home point goes
+    assert len(clip_home_area(track, HOME, 1000.0)) == 1  # 700 m now excluded too
+
+
+def test_clip_rejects_non_positive_radius():
+    # A zero radius would silently disable clipping; refuse rather than no-op.
+    with pytest.raises(ValueError):
+        clip_home_area([(0.0, 0.0)], HOME, 0.0)
+
+
+def test_clipping_handles_a_home_near_the_antimeridian():
+    # 179.999E and 179.999W are ~200 m apart, not ~360 degrees. Treating the raw
+    # difference as the distance would keep a point right next to the house.
+    home = (0.0, 179.999)
+    just_across = (0.0, -179.999)
+    assert clip_home_area([just_across], home, 500.0) == []
+    # A genuinely distant point at the same latitude still survives.
+    assert clip_home_area([(0.0, 179.98)], home, 500.0) == [(0.0, 179.98)]
+
+
+# --- gridding ---------------------------------------------------------------
+
+
+def test_grid_cells_are_roughly_square_in_metres():
+    lat_step, lng_step = grid_steps(HEATMAP_CELL_SIZE_M, HOME[0])
+    height_m = lat_step * METERS_PER_DEGREE_LAT
+    width_m = lng_step * METERS_PER_DEGREE_LAT * math.cos(math.radians(HOME[0]))
+    assert height_m == pytest.approx(HEATMAP_CELL_SIZE_M, rel=0.01)
+    # Without the cos(lat) correction this would be ~2x too wide at 60°N.
+    assert width_m == pytest.approx(HEATMAP_CELL_SIZE_M, rel=0.01)
+
+
+def test_nearby_points_collapse_into_one_cell():
+    lat_step, lng_step = grid_steps(HEATMAP_CELL_SIZE_M, HOME[0])
+    # Three samples a couple of metres apart — one cell, not three.
+    track = [_offset_point(HOME, north_m=1000 + d) for d in (0, 2, 4)]
+    assert len(track_cells(track, lat_step, lng_step)) == 1
+
+
+def test_distant_points_land_in_different_cells():
+    lat_step, lng_step = grid_steps(HEATMAP_CELL_SIZE_M, HOME[0])
+    track = [_offset_point(HOME, north_m=1000 + d) for d in (0, 60, 120)]
+    assert len(track_cells(track, lat_step, lng_step)) == 3
+
+
+def test_emitted_precision_does_not_merge_distinct_cells():
+    # 4 decimals must resolve finer than the cell, or neighbouring cells would
+    # collapse and counts would silently merge.
+    lat_step, _ = grid_steps(HEATMAP_CELL_SIZE_M, HOME[0])
+    assert lat_step > 10**-CELL_COORD_PRECISION
+
+
+# --- aggregation ------------------------------------------------------------
+
+
+def _track_polyline(north_range, east_m=0.0):
+    return _encode([_offset_point(HOME, north_m=d, east_m=east_m) for d in north_range])
+
+
+def test_counts_are_per_activity_not_per_gps_sample():
+    # One activity that dawdles (many samples in one cell) must contribute 1,
+    # not 20 — otherwise the map highlights where the running is slowest.
+    dawdling = _encode([_offset_point(HOME, north_m=1000 + d * 0.1) for d in range(20)])
+    grid = build_heatmap([dawdling], HOME, 500.0)
+    assert grid["max_count"] == 1
+    assert len(grid["cells"]) == 1
+
+
+def test_repeated_route_accumulates_counts():
+    track = _track_polyline(range(600, 1200, 10))
+    grid = build_heatmap([track] * 5, HOME, 500.0)
+    assert grid["max_count"] == 5
+    assert grid["gps_activity_count"] == 5
+    assert all(cell[2] == 5 for cell in grid["cells"])
+
+
+def test_aggregate_excludes_the_home_area():
+    grid = build_heatmap([_track_polyline(range(0, 3000, 10))], HOME, 500.0)
+    assert grid["cells"]
+    for lng, lat, _count in grid["cells"]:
+        assert _metres_from_home(lat, lng) > 500.0
+
+
+def test_no_emitted_cell_footprint_overlaps_the_exclusion_circle():
+    # Clipping filters points, but snapping then shifts each survivor by up to
+    # half a cell diagonal — so a point legally outside the radius could produce
+    # a cell centred inside it. Approach the boundary from every direction at
+    # 1 m resolution and assert the whole cell, not just its centre, stays out.
+    radius = 500.0
+    tracks = []
+    for bearing in range(0, 360, 5):
+        rad = math.radians(bearing)
+        tracks.append(
+            _encode([
+                _offset_point(HOME, north_m=d * math.cos(rad), east_m=d * math.sin(rad))
+                for d in range(400, 700)
+            ])
+        )
+
+    grid = build_heatmap(tracks, HOME, radius)
+    assert grid["cells"], "the fixture should still produce cells further out"
+
+    cell_reach = HEATMAP_CELL_SIZE_M * math.sqrt(2) / 2
+    for lng, lat, _count in grid["cells"]:
+        assert _metres_from_home(lat, lng) >= radius + cell_reach
+
+
+def test_bounds_enclose_every_cell():
+    grid = build_heatmap(
+        [_track_polyline(range(600, 2000, 10)), _track_polyline(range(600, 2000, 10), east_m=800)],
+        HOME,
+        500.0,
+    )
+    min_lng, min_lat, max_lng, max_lat = grid["bounds"]
+    for lng, lat, _count in grid["cells"]:
+        assert min_lng <= lng <= max_lng
+        assert min_lat <= lat <= max_lat
+
+
+def test_activities_without_gps_are_skipped_not_counted():
+    grid = build_heatmap([None, "", _track_polyline(range(600, 1200, 10))], HOME, 500.0)
+    assert grid["gps_activity_count"] == 1
+
+
+def test_corrupt_polyline_does_not_break_the_aggregate():
+    # One bad activity must not fail the whole response.
+    grid = build_heatmap(["_p~iF~ps|U_ulL", _track_polyline(range(600, 1200, 10))], HOME, 500.0)
+    assert grid["gps_activity_count"] == 1
+    assert grid["cells"]
+
+
+def test_route_never_leaving_the_radius_contributes_nothing():
+    grid = build_heatmap([_track_polyline(range(0, 400, 10))], HOME, 500.0)
+    assert grid == {"cells": [], "bounds": None, "max_count": 0, "gps_activity_count": 0}
+
+
+def test_cells_are_unique_and_deterministically_ordered():
+    grid = build_heatmap([_track_polyline(range(600, 3000, 7))] * 3, HOME, 500.0)
+    coords = [(c[0], c[1]) for c in grid["cells"]]
+    assert len(coords) == len(set(coords))
+    assert coords == sorted(coords)
+
+
+# --- endpoint contract ------------------------------------------------------
+
+HOME_TRACK_POLYLINE = _track_polyline(range(0, 3000, 10))
+
+
+def _activity(activity_id=1, polyline=HOME_TRACK_POLYLINE, distance=9399.8):
+    from apps.strava.models import StravaActivity
+
+    return StravaActivity(
+        id=activity_id,
+        name="Morning Run",
+        type="Run",
+        distance=distance,
+        moving_time=3474,
+        elapsed_time=3600,
+        total_elevation_gain=131.0,
+        start_date=datetime(2026, 7, 24, 14, 4, 37, tzinfo=UTC),
+        start_date_local=datetime(2026, 7, 24, 16, 4, 37),
+        summary_polyline=polyline,
+    )
+
+
+def _fake_db(rows, last_synced="2026-07-24T20:00:00", has_any=True):
+    """A session whose aggregate and polyline queries both answer from `rows`."""
+    query = MagicMock()
+    query.filter.return_value = query
+    query.with_entities.return_value.one.return_value = (
+        len(rows),
+        sum(r.distance for r in rows),
+        last_synced,
+    )
+    query.with_entities.return_value.all.return_value = [(r.summary_polyline,) for r in rows]
+    query.first.return_value = object() if has_any else None
+
+    db = MagicMock()
+    db.query.return_value = query
+    return db
+
+
+@pytest.fixture
+def client(monkeypatch):
+    import apps.strava.main as main
+
+    monkeypatch.setattr(settings, "strava_home_lat", HOME[0])
+    monkeypatch.setattr(settings, "strava_home_lng", HOME[1])
+    monkeypatch.setattr(settings, "strava_privacy_radius_m", 500.0)
+    main._HEATMAP_CACHE.clear()  # a process-wide cache would leak between tests
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+def _use_db(db):
+    app.dependency_overrides[get_db] = lambda: db
+
+
+def test_response_shape_is_stable(client):
+    _use_db(_fake_db([_activity()]))
+    r = client.get("/strava/heatmap?activity_type=Run")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert set(body) == {
+        "cell_size_m",
+        "bounds",
+        "max_count",
+        "activity_count",
+        "total_distance_m",
+        "cells",
+    }
+    assert body["cell_size_m"] == HEATMAP_CELL_SIZE_M
+    assert body["activity_count"] == 1
+    assert body["total_distance_m"] == 9400
+    assert len(body["bounds"]) == 4
+
+    # Triples, not objects.
+    lng, lat, count = body["cells"][0]
+    assert isinstance(count, int)
+    assert round(lng, CELL_COORD_PRECISION) == lng
+    assert round(lat, CELL_COORD_PRECISION) == lat
+
+
+def test_response_never_leaks_home_coordinate_radius_or_raw_track(client):
+    _use_db(_fake_db([_activity()]))
+    raw = client.get("/strava/heatmap").text
+
+    assert "59.9139" not in raw
+    assert "10.7522" not in raw
+    assert "radius" not in raw.lower()
+    assert HOME_TRACK_POLYLINE not in raw
+
+
+def test_response_carries_no_link_back_to_individual_activities(client):
+    _use_db(_fake_db([_activity(activity_id=19446762736)]))
+    raw = client.get("/strava/heatmap").text
+
+    assert "19446762736" not in raw          # no activity IDs
+    assert "start_date" not in raw           # no timestamps
+    assert "2026-07-24" not in raw
+
+
+def test_cells_are_clipped_around_home(client):
+    _use_db(_fake_db([_activity()]))
+    for lng, lat, _count in client.get("/strava/heatmap").json()["cells"]:
+        assert _metres_from_home(lat, lng) > 500.0
+
+
+def test_wider_radius_clips_more(client, monkeypatch):
+    import apps.strava.main as main
+
+    _use_db(_fake_db([_activity()]))
+    narrow = client.get("/strava/heatmap").json()["cells"]
+
+    monkeypatch.setattr(settings, "strava_privacy_radius_m", 1500.0)
+    main._HEATMAP_CACHE.clear()
+    wide = client.get("/strava/heatmap").json()["cells"]
+
+    assert len(wide) < len(narrow)
+    for lng, lat, _count in wide:
+        assert _metres_from_home(lat, lng) > 1500.0
+
+
+def test_refuses_to_serve_when_home_is_unconfigured(client, monkeypatch):
+    # The fail-closed case: no config must mean no data, not unclipped data.
+    monkeypatch.setattr(settings, "strava_home_lat", None)
+    _use_db(_fake_db([_activity()]))
+    r = client.get("/strava/heatmap")
+    assert r.status_code == 503
+    assert "cells" not in r.json()
+
+
+def test_no_matching_activities_is_200_but_unsynced_backend_is_503(client):
+    # "No rides logged" and "Strava never synced" must be distinguishable.
+    _use_db(_fake_db([], has_any=True))
+    r = client.get("/strava/heatmap?activity_type=Ride")
+    assert r.status_code == 200
+    assert r.json()["cells"] == [] and r.json()["bounds"] is None
+
+    _use_db(_fake_db([], has_any=False))
+    assert client.get("/strava/heatmap").status_code == 503
+
+
+def test_activities_without_gps_still_count_in_the_summary(client):
+    # A treadmill run has no track but did happen, and its distance is real.
+    _use_db(_fake_db([_activity(polyline=None, distance=5000.0)]))
+    body = client.get("/strava/heatmap").json()
+    assert body["activity_count"] == 1
+    assert body["total_distance_m"] == 5000
+    assert body["cells"] == []
+
+
+# --- caching ----------------------------------------------------------------
+
+
+def test_etag_revalidation_returns_304(client):
+    _use_db(_fake_db([_activity()]))
+    first = client.get("/strava/heatmap")
+    etag = first.headers["etag"]
+
+    cache_control = first.headers["cache-control"]
+    assert cache_control.startswith("public")
+    # The aggregate only moves when a new activity is logged.
+    assert "max-age=3600" in cache_control
+    assert "stale-while-revalidate" in cache_control
+
+    second = client.get("/strava/heatmap", headers={"If-None-Match": etag})
+    assert second.status_code == 304
+    assert second.headers["etag"] == etag
+    assert not second.content
+
+
+def test_etag_is_weak_and_matches_when_echoed_verbatim(client):
+    # Regression guard: the served tag is W/-prefixed, so the If-None-Match
+    # comparison has to normalise both sides. Comparing a prefixed tag against
+    # stripped candidates silently never matches and 304 stops happening.
+    _use_db(_fake_db([_activity()]))
+    etag = client.get("/strava/heatmap").headers["etag"]
+    assert etag.startswith('W/"')
+
+    for header in (etag, _strip_weak(etag), f'"nope", {etag}', "*"):
+        r = client.get("/strava/heatmap", headers={"If-None-Match": header})
+        assert r.status_code == 304, f"no 304 for If-None-Match: {header}"
+
+
+def test_etag_changes_when_privacy_config_changes(client, monkeypatch):
+    _use_db(_fake_db([_activity()]))
+    before = client.get("/strava/heatmap").headers["etag"]
+
+    monkeypatch.setattr(settings, "strava_privacy_radius_m", 1500.0)
+    assert client.get("/strava/heatmap").headers["etag"] != before
+
+
+def test_etag_changes_when_a_new_activity_is_synced(client):
+    _use_db(_fake_db([_activity()], last_synced="2026-07-24T20:00:00"))
+    before = client.get("/strava/heatmap").headers["etag"]
+
+    _use_db(_fake_db([_activity(), _activity(activity_id=2)], last_synced="2026-07-25T09:00:00"))
+    assert client.get("/strava/heatmap").headers["etag"] != before
+
+
+def test_etag_distinguishes_activity_types(client):
+    _use_db(_fake_db([_activity()]))
+    tags = {
+        client.get(f"/strava/heatmap{qs}").headers["etag"]
+        for qs in ("", "?activity_type=Run", "?activity_type=Ride")
+    }
+    assert len(tags) == 3
+
+
+def test_etag_does_not_expose_the_home_coordinate(client):
+    # The tag commits to the home coordinate so config changes bust caches, but
+    # coordinates are low-entropy: an unkeyed digest could be brute-forced back
+    # out of a public header. It is HMACed with a server secret instead.
+    import hashlib
+
+    _use_db(_fake_db([_activity()]))
+    tag = client.get("/strava/heatmap").headers["etag"]
+    guess = hashlib.sha256(f"{HOME[0]}|{HOME[1]}|500.0".encode()).hexdigest()[:32]
+    assert guess not in tag
+
+
+def test_repeat_request_is_served_from_cache_without_reaggregating(client):
+    db = _fake_db([_activity()])
+    _use_db(db)
+
+    first = client.get("/strava/heatmap").json()
+    calls_after_first = db.query.return_value.with_entities.return_value.all.call_count
+
+    second = client.get("/strava/heatmap").json()
+    assert second == first
+    # The polyline fetch (and the aggregation behind it) did not run again.
+    assert db.query.return_value.with_entities.return_value.all.call_count == calls_after_first
+
+
+def test_large_response_is_compressed(client):
+    # Uncompressed a full heat grid is hundreds of KB; the frontend has a 5 s
+    # budget and the reverse proxy's compression config lives outside this repo.
+    tracks = [
+        _activity(activity_id=i, polyline=_track_polyline(range(600, 12000, 6), east_m=i * 40))
+        for i in range(40)
+    ]
+    _use_db(_fake_db(tracks))
+
+    r = client.get("/strava/heatmap", headers={"Accept-Encoding": "gzip"})
+    assert r.headers.get("content-encoding") == "gzip"
+    decoded = r.content
+    assert len(decoded) > 100_000
+    assert len(gzip.compress(decoded)) < len(decoded) / 2
+
+
+# --- separation from the lightweight endpoint -------------------------------
+
+
+def test_cors_allows_the_public_site(client):
+    _use_db(_fake_db([_activity()]))
+    r = client.get("/strava/heatmap", headers={"Origin": "https://vuhnger.dev"})
+    assert r.headers.get("access-control-allow-origin") == "https://vuhnger.dev"
+
+
+def test_lightweight_activities_endpoint_stays_free_of_geometry(client):
+    # The stat cards poll /strava/activities; summary_polyline is unclipped and
+    # must never appear there.
+    assert "summary_polyline" not in _activity().to_dict()


### PR DESCRIPTION
Bygget etter bestillingen fra frontend (vuhnger.dev). Erstatter det tidligere skisserte rutegeometri-endepunktet.

## Endepunkt

```
GET /strava/heatmap?activity_type=Run
```

```json
{
  "cell_size_m": 15.0,
  "bounds": [10.6221, 59.8732, 10.745, 59.9958],
  "max_count": 27,
  "activity_count": 120,
  "total_distance_m": 1128000,
  "cells": [[10.6221, 59.9286, 2]]
}
```

`activity_type` er eneste filter — aggregatet dekker alle år. `bounds` er `null` når ingenting matcher.

## Personvern

Sporene er absolutte WGS84 på vei til en offentlig side, så:

- **Klipping** fjerner alle punkter innenfor konfigurert radius (default 500 m) av hjemmekoordinatet — også midt i en tur, ikke bare i endene. Avstanden er radiell og håndterer antimeridianen.
- **Snapping skjer etter klipping** og kan flytte et punkt opptil en halv celle-diagonal. Cellene sjekkes derfor på nytt mot radius pluss cellens eget fotavtrykk, så ingen publisert celle overlapper eksklusjonssirkelen. Uten dette havnet nærmeste cellesenter 489,8 m fra hjemmet — 10,2 m inne i sonen.
- **Aggregatet har ingen tidsstempler, aktivitets-ID-er eller punktrekkefølge.** Enkeltturer kan ikke rekonstrueres.
- **Celler teller aktiviteter, ikke GPS-punkter.** Punkttetthet følger tempo, så rå punkttelling ville framhevet der man løper saktest — og kodet et "oppholder seg her"-signal.
- **Hjemmekoordinat og radius ligger i config og finnes aldri i responsen.** Mangler de, svarer endepunktet 503 i stedet for å servere uklippet data.

## Krav fra bestillingen

| Krav | Status |
|---|---|
| Timeout < 5 s | 113 ms kald, 5 ms ved revalidering |
| CORS for vuhnger.dev | `access-control-allow-origin: https://vuhnger.dev` |
| Stabil shape for Zod | Faste nøkler, `bounds` nullable, dekket av tester |
| ETag + lang Cache-Control | `W/"..."` + `public, max-age=3600, stale-while-revalidate=86400` |
| Ekte statuskode ved feil | 503 = usynket/DB nede/uklippet-config; 200 med tomme `cells` = filteret traff ingenting |
| Cells som tripler | `[lng, lat, count]`, 4 desimaler |
| Ingen paginering | Hele aggregatet i ett svar |

## Implementasjon

Geometrien kommer fra `map.summary_polyline` i Stravas **liste**-respons, så den følger med den eksisterende synken — ingen kall per aktivitet, ingen risiko mot rate-limiten (100/15 min). Ny nullable kolonne `summary_polyline` lagrer den rå; klipping og aggregering skjer per request fordi radius og hjemmekoordinat må kunne endres uten full re-sync.

ETag-en er HMAC-et med server-secret. Den forplikter seg til hjemmekoordinatet så en config-endring buster cachen, men koordinater har lav entropi — en usaltet digest kunne brute-forces tilbake ut av en offentlig header. Samme ETag brukes som nøkkel i en liten prosess-cache, så et cache-treff hopper over aggregeringen helt.

Gzip er slått på i den delte app-factoryen: Caddy komprimerer ikke uten `encode`-direktiv, og den konfigurasjonen ligger utenfor repoet.

## Etter merge

Kolonnen er tom for alle eksisterende turer. Heatmapet er tomt til en full re-sync har kjørt:

```
POST /strava/refresh-data?full=true    # krever X-API-Key
```

`STRAVA_HOME_LAT` og `STRAVA_HOME_LNG` må settes på server før endepunktet svarer med noe annet enn 503.

## Verifisering

- 91 tester grønne (ruff + mypy rene)
- CodeRabbit: ingen funn (fant 3 i første runde, alle fikset — inkludert celle-overlapp-buggen over)
- Ende-til-ende mot ekte Postgres med 120 seedede aktiviteter: 7 511 celler, 25 kB gzipet, nærmeste celle 511,4 m fra hjemmet, ingen koordinat/ID/tidsstempel i responsen
- Migrasjon kjørt fra bunn mot tom database