### PR TITLE
ops: server health scripts (backup, restore test, watchdog, caddy reload)

### DIFF
--- a/ops/README.md
+++ b/ops/README.md
@@ -1,0 +1,109 @@
+# ops/
+
+Server-side operational scripts for the NREC host. They are not part of the
+application and are not deployed by `deploy.yml`; install them explicitly:
+
+```bash
+ssh nrec
+cd ~/backend && git pull
+ops/install.sh
+```
+
+## Why these exist
+
+Four things broke on 2026-07-25, and the monitoring at the time reported a
+healthy system throughout every one of them:
+
+| What happened | Why nothing noticed |
+|---|---|
+| The Caddyfile was syntactically invalid for hours | Caddy keeps serving its last good config from memory. `systemctl is-active` said `active`; every endpoint returned 200. Only a reboot would have surfaced it, by taking every site down at once. |
+| systemd (PID 1) grew to 890 MB | 64,576 failed `systemd-coredump@*` unit tombstones, retained in RAM forever. Eventually systemd could not fork and every `systemctl` verb failed with ENOMEM. |
+| `ruta.vuhnger.dev` served no certificate for 77 days | Nothing checked certificate expiry. Caddy retried ACME every 10 minutes into the void. |
+| The root disk reached 80% | Nothing checked disk, and a 39 GB second volume sat mounted and empty the whole time. |
+
+The common shape is **silent degradation**: the system looked fine until two
+problems coincided. So `server-watchdog.sh` measures how much margin is left,
+rather than whether things are currently up.
+
+## Scripts
+
+| Script | Schedule | What it does |
+|---|---|---|
+| `server-watchdog.sh` | hourly, :07 | Containers, public endpoints through Caddy, disk, memory, swap, PID 1 RSS, unit counts, Caddyfile validity, TLS expiry, backup age |
+| `pg-backup.sh` | nightly, 02:30 | `pg_dump -Fc` → `/mnt/docker-data/backups/postgres`, verified before being accepted, then rotated |
+| `pg-restore-test.sh` | Sundays, 04:00 | Restores the newest dump into a throwaway container and counts the tables |
+| `caddy-reload.sh` | manual | validate → reload → verify against the admin API → commit to `/etc/caddy` |
+
+All four alert to the same Discord webhook the previous healthcheck used:
+`~/.config/backend-healthcheck/discord_webhook_url`. The URL exists only in that
+file — never in a script, a cron entry, or this repo.
+
+## Design notes
+
+**Backups are verified, not assumed.** `pg_dump` exiting 0 only proves a file was
+written. `pg-backup.sh` writes to `.partial`, runs `pg_restore --list` against it,
+and only then renames it to a real backup name — so the directory can never hold a
+file that looks like a backup but is not one. `pg-restore-test.sh` goes further and
+restores into a live throwaway database weekly, because a backup nobody has ever
+restored is a guess.
+
+**Rotation has a floor.** Deleting by age alone would erase every backup after a
+fortnight of the job failing unnoticed. `MIN_KEEP` (default 7) is never crossed
+regardless of age.
+
+**Credentials stay in the container.** `pg_dump` runs via `docker exec` and reads
+`POSTGRES_USER`/`POSTGRES_DB` from the environment compose already gave the
+database container. No secret reaches these scripts, the cron entries, or `ps`.
+
+**Alerts deduplicate.** A condition that stays broken re-alerts at most every
+`REMIND_HOURS` (default 12), and any change in the problem set alerts immediately.
+An alert channel that cries every hour stops being read.
+
+**`caddy-reload.sh` falls back to the admin API.** `systemctl reload` needs systemd
+to fork a helper process, which is exactly what fails under the memory pressure you
+most want to fix. The admin API runs inside the existing Caddy process and needs no
+fork.
+
+## Configuration
+
+Every threshold is an environment variable with a default; nothing is hardcoded.
+The ones worth knowing:
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `DISK_WARN_PCT` | `85` | Alert above this fill level |
+| `MEM_MIN_MB` | `250` | Alert below this much available memory |
+| `PID1_MAX_MB` | `200` | Alert if systemd exceeds this (normal is ~15 MB) |
+| `UNITS_MAX` | `1000` | Alert on unit-tombstone accumulation |
+| `CERT_MIN_DAYS` | `14` | Alert this long before a certificate expires |
+| `BACKUP_MAX_AGE_H` | `30` | Alert if the last good backup is older than this |
+| `RETENTION_DAYS` | `14` | Backup age limit |
+| `MIN_KEEP` | `7` | Backups never rotated below this count |
+
+## Recovering from the PID 1 leak
+
+If the watchdog reports systemd using hundreds of MB, the order matters:
+
+```bash
+systemctl reset-failed     # clear the tombstones FIRST
+systemctl daemon-reexec    # then reclaim the heap
+```
+
+Doing `daemon-reexec` first makes it worse — it re-serializes every retained unit.
+Observed on 2026-07-25: 849 MB → 1,325 MB in the wrong order, then 1,325 MB → 13 MB
+in the right one.
+
+## Restoring a backup for real
+
+```bash
+ls -lt /mnt/docker-data/backups/postgres/
+docker compose stop strava-api wakatime-api projects-api site-api n8n-api
+docker exec -i backend-db-1 sh -c \
+  'pg_restore -U "$POSTGRES_USER" -d "$POSTGRES_DB" --clean --if-exists' \
+  < /mnt/docker-data/backups/postgres/backend_db-<stamp>.dump
+docker compose start strava-api wakatime-api projects-api site-api n8n-api
+```
+
+Backups are on `/dev/sdb`, a separate physical volume from the root disk, but still
+on this host. They protect against a deleted volume, a bad migration, and disk
+corruption — not against losing the VM. Off-site copies are not set up.

--- a/ops/README.md
+++ b/ops/README.md
@@ -107,3 +107,36 @@ docker compose start strava-api wakatime-api projects-api site-api n8n-api
 Backups are on `/dev/sdb`, a separate physical volume from the root disk, but still
 on this host. They protect against a deleted volume, a bad migration, and disk
 corruption — not against losing the VM. Off-site copies are not set up.
+
+## Where Docker keeps its data
+
+Since 2026-07-25 the data-root is `/mnt/docker-data/docker` on `/dev/sdb`, not
+`/var/lib/docker`. `/etc/docker/daemon.json`:
+
+```json
+{
+  "data-root": "/mnt/docker-data/docker",
+  "log-driver": "json-file",
+  "log-opts": { "max-size": "10m", "max-file": "3" }
+}
+```
+
+Root went from 81% to 69%. Note that both the images and the backups now sit on the
+same physical volume — a `/dev/sdb` failure takes out both at once.
+
+Three things bite anyone repeating this move:
+
+- **SELinux is Enforcing.** A fresh directory is `unlabeled_t` and Docker cannot
+  use it. `semanage fcontext -a -e /var/lib/docker <path>` then `restorecon -R`.
+- **`systemctl stop docker` does not keep it stopped.** `docker.socket` is
+  socket-activated, so any docker client — or one `systemctl start docker` from
+  someone who noticed the site was down — restarts the daemon and lets Postgres
+  write into the tree being copied. `systemctl mask docker.service docker.socket`
+  for the duration, and verify with `pgrep containerd-shim` before copying.
+- **`log-opts` apply at container creation, not start.** `docker compose up -d`
+  reuses existing containers and silently keeps the old unlimited logging;
+  `--force-recreate` is what actually applies it. Check with
+  `docker inspect <c> --format '{{.HostConfig.LogConfig.Config}}'`.
+
+Verify a move with a `--dry-run --itemize-changes` rsync (must print nothing) rather
+than comparing `du` output, which differs across filesystems and hardlinks.

--- a/ops/caddy-reload.sh
+++ b/ops/caddy-reload.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+#
+# Safe Caddy reload.
+#
+# On 2026-07-25 the Caddyfile sat syntactically invalid for hours without a single
+# symptom: caddy kept serving its last good in-memory config, systemctl reported
+# active, and every endpoint returned 200. The only thing that would have surfaced
+# it was a reboot, at which point every site would have gone down at once.
+#
+# This script makes that state unreachable by tying the four steps together:
+#   1. validate the file           -- never load something that does not parse
+#   2. reload                      -- systemctl, falling back to the admin API
+#   3. verify against the admin API -- prove the running config is the file's
+#   4. commit                      -- /etc/caddy is a git repo; keep it honest
+#
+# Usage:  caddy-reload.sh ["commit message"]
+
+set -euo pipefail
+
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/common.sh"
+
+CADDYFILE="${CADDYFILE:-/etc/caddy/Caddyfile}"
+ADMIN="${CADDY_ADMIN:-http://localhost:2019}"
+
+main() {
+    require_cmd caddy curl python3
+    [[ -f "$CADDYFILE" ]] || die "no such file: $CADDYFILE"
+
+    local adapted
+    adapted="$(mktemp)"
+    trap 'rm -f "$adapted"' EXIT
+
+    log "validating $CADDYFILE"
+    if ! caddy validate --adapter caddyfile --config "$CADDYFILE" >/dev/null 2>&1; then
+        # Re-run without suppression so the operator sees the parse error itself.
+        caddy validate --adapter caddyfile --config "$CADDYFILE" 2>&1 | grep -i error >&2 || true
+        die "Caddyfile is invalid; nothing was reloaded"
+    fi
+    log "valid"
+
+    caddy adapt --adapter caddyfile --config "$CADDYFILE" > "$adapted" 2>/dev/null \
+        || die "could not adapt config"
+
+    reload "$adapted"
+    verify "$adapted"
+    commit "${1:-update Caddyfile}"
+
+    log "reload complete and verified"
+}
+
+reload() {
+    local adapted="$1"
+
+    if sudo systemctl reload caddy 2>/dev/null; then
+        log "reloaded via systemctl"
+        return 0
+    fi
+
+    # systemctl reload needs systemd to fork a helper, which fails under memory
+    # pressure (see ops/README.md). The admin API runs inside the existing caddy
+    # process and needs no fork, so it still works when systemctl does not.
+    log "systemctl reload failed; falling back to the admin API"
+    local code
+    code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 30 \
+        -X POST -H 'Content-Type: application/json' \
+        --data-binary "@$adapted" "$ADMIN/load")"
+
+    [[ "$code" == "200" ]] || die "admin API load returned HTTP $code"
+    log "reloaded via admin API"
+}
+
+# Compare what caddy is actually running against what the file says. Without this
+# the script would report success for a reload that silently did not take.
+verify() {
+    local adapted="$1"
+    local live
+    live="$(mktemp)"
+
+    curl -fsS --max-time 15 "$ADMIN/config/" > "$live" || {
+        rm -f "$live"
+        die "could not read running config from the admin API"
+    }
+
+    if python3 -c '
+import json, sys
+with open(sys.argv[1]) as f: want = json.load(f)
+with open(sys.argv[2]) as f: live = json.load(f)
+sys.exit(0 if want.get("apps") == live.get("apps") else 1)
+' "$adapted" "$live"; then
+        log "running config matches $CADDYFILE"
+        rm -f "$live"
+    else
+        rm -f "$live"
+        die "running config does NOT match $CADDYFILE -- reload did not take effect"
+    fi
+}
+
+commit() {
+    local message="$1"
+    local dir
+    dir="$(dirname "$CADDYFILE")"
+
+    [[ -d "$dir/.git" ]] || { log "no git repo in $dir; skipping commit"; return 0; }
+
+    if sudo git -C "$dir" diff --quiet -- "$(basename "$CADDYFILE")" 2>/dev/null; then
+        log "no changes to commit"
+        return 0
+    fi
+
+    sudo git -C "$dir" add "$(basename "$CADDYFILE")"
+    sudo git -C "$dir" commit -q -m "$message"
+    log "committed: $message"
+}
+
+main "$@"

--- a/ops/caddy-reload.sh
+++ b/ops/caddy-reload.sh
@@ -22,13 +22,23 @@ set -euo pipefail
 CADDYFILE="${CADDYFILE:-/etc/caddy/Caddyfile}"
 ADMIN="${CADDY_ADMIN:-http://localhost:2019}"
 
+# File scope, not local to main: the EXIT trap fires after main has returned, so
+# a local would be out of scope by then and `set -u` would abort the trap -- which
+# made the script exit non-zero after a completely successful reload.
+ADAPTED=""
+
+cleanup() {
+    [[ -n "$ADAPTED" ]] && rm -f "$ADAPTED"
+    return 0
+}
+trap cleanup EXIT
+
 main() {
     require_cmd caddy curl python3
     [[ -f "$CADDYFILE" ]] || die "no such file: $CADDYFILE"
 
-    local adapted
-    adapted="$(mktemp)"
-    trap 'rm -f "$adapted"' EXIT
+    ADAPTED="$(mktemp)"
+    local adapted="$ADAPTED"
 
     log "validating $CADDYFILE"
     if ! caddy validate --adapter caddyfile --config "$CADDYFILE" >/dev/null 2>&1; then

--- a/ops/common.sh
+++ b/ops/common.sh
@@ -72,12 +72,19 @@ require_cmd() {
     done
 }
 
+# Locks live under $HOME, not /var/lock: that directory is root-owned, so these
+# scripts cannot create a lock file there and would abort on every cron run.
+LOCK_DIR="${LOCK_DIR:-$HOME/.local/state/backend-ops}"
+
 # Single-instance guard. A backup that overruns its hour must not have a second
 # copy started on top of it.
 #
-#   hold_lock /var/lock/pg-backup.lock
+#   hold_lock pg-backup
 hold_lock() {
-    local lockfile="$1"
+    local name="$1"
+    local lockfile="$LOCK_DIR/$name.lock"
+
+    mkdir -p "$LOCK_DIR" || die "cannot create lock directory: $LOCK_DIR"
     exec 9>"$lockfile" || die "cannot open lock file: $lockfile"
     flock -n 9 || {
         log "another instance is already running ($lockfile); exiting"

--- a/ops/common.sh
+++ b/ops/common.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# Shared helpers for the ops scripts. Source it, do not execute it:
+#
+#   . "$(dirname "$0")/common.sh"
+#
+# Every script here runs unattended from cron, so the rules are: fail loudly to
+# the notifier, never print secrets, and never block forever on the network.
+
+# Cron gets a minimal PATH. linuxbrew first because python3 and docker live there.
+PATH=/home/linuxbrew/.linuxbrew/bin:/usr/local/bin:/usr/bin:/bin
+export PATH
+
+# Where the Discord webhook URL is kept. One line, no trailing junk. The file is
+# the only place the URL exists -- it must never be baked into a script or a cron
+# entry, both of which end up in git or in `ps` output.
+WEBHOOK_FILE="${WEBHOOK_FILE:-$HOME/.config/backend-healthcheck/discord_webhook_url}"
+
+# Discord rejects payloads over 2000 characters outright, so a long alert would
+# be silently lost -- exactly when you most want it delivered.
+readonly MAX_MESSAGE_CHARS=1900
+
+log() {
+    printf '%s %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$*"
+}
+
+die() {
+    log "FATAL: $*" >&2
+    exit 1
+}
+
+# send_notification <message>
+#
+# Returns non-zero if the message could not be delivered, so callers can decide
+# whether an undeliverable alert is itself fatal.
+send_notification() {
+    local message="$1"
+    local webhook_url payload
+
+    if [[ ! -s "$WEBHOOK_FILE" ]]; then
+        log "cannot notify: webhook file missing or empty: $WEBHOOK_FILE" >&2
+        return 1
+    fi
+
+    webhook_url="$(<"$WEBHOOK_FILE")"
+
+    if (( ${#message} > MAX_MESSAGE_CHARS )); then
+        message="${message:0:$MAX_MESSAGE_CHARS}"$'\n[...avkortet]'
+    fi
+
+    # Build the JSON in python rather than by string concatenation: an alert body
+    # containing a quote or a newline would otherwise produce invalid JSON and the
+    # alert would vanish.
+    payload="$(CONTENT="$message" python3 -c '
+import json, os
+print(json.dumps({"content": os.environ["CONTENT"]}))
+')" || {
+        log "cannot notify: failed to build payload" >&2
+        return 1
+    }
+
+    curl -fsS --max-time 15 --retry 2 --retry-delay 3 \
+        -H "Content-Type: application/json" \
+        -d "$payload" "$webhook_url" >/dev/null
+}
+
+# require_cmd <name>...
+require_cmd() {
+    local cmd
+    for cmd in "$@"; do
+        command -v "$cmd" >/dev/null 2>&1 || die "required command not found: $cmd"
+    done
+}
+
+# Single-instance guard. A backup that overruns its hour must not have a second
+# copy started on top of it.
+#
+#   hold_lock /var/lock/pg-backup.lock
+hold_lock() {
+    local lockfile="$1"
+    exec 9>"$lockfile" || die "cannot open lock file: $lockfile"
+    flock -n 9 || {
+        log "another instance is already running ($lockfile); exiting"
+        exit 0
+    }
+}

--- a/ops/install.sh
+++ b/ops/install.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# Installs the ops scripts and their cron entries on the server. Idempotent --
+# safe to re-run after every deploy.
+#
+# Cron entries live inside a marked block so re-running rewrites only that block
+# and leaves hand-written entries (the hourly strava/wakatime tasks) untouched.
+#
+# Usage:  ops/install.sh [--uninstall]
+
+set -euo pipefail
+
+SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEST_DIR="${DEST_DIR:-$HOME/ops}"
+LOG_DIR="${LOG_DIR:-$HOME/logs}"
+BACKUP_DIR="${BACKUP_DIR:-/mnt/docker-data/backups/postgres}"
+
+BEGIN_MARK="# >>> backend ops (managed by ops/install.sh) >>>"
+END_MARK="# <<< backend ops <<<"
+
+main() {
+    [[ "${1:-}" == "--uninstall" ]] && { uninstall; exit 0; }
+
+    install_scripts
+    install_dirs
+    install_cron
+    verify
+
+    cat <<EOF
+
+Installert i $DEST_DIR. Cron-blokka er skrevet.
+
+Neste steg, som ikke gjøres automatisk fordi de trenger et menneske:
+  1. Sjekk at webhooken finnes:  test -s ~/.config/backend-healthcheck/discord_webhook_url
+  2. Tørrkjør vaktbikkja:        $DEST_DIR/server-watchdog.sh --dry-run
+  3. Ta en backup nå:            $DEST_DIR/pg-backup.sh
+  4. Bevis at den kan gjenopprettes: $DEST_DIR/pg-restore-test.sh
+EOF
+}
+
+install_scripts() {
+    mkdir -p "$DEST_DIR"
+    install -m 0644 "$SRC_DIR/common.sh" "$DEST_DIR/common.sh"
+
+    local script
+    for script in pg-backup.sh pg-restore-test.sh server-watchdog.sh caddy-reload.sh; do
+        install -m 0755 "$SRC_DIR/$script" "$DEST_DIR/$script"
+        echo "installed $DEST_DIR/$script"
+    done
+}
+
+install_dirs() {
+    mkdir -p "$LOG_DIR"
+
+    # The backup directory lives on the large second disk, not the root volume.
+    if [[ ! -d "$BACKUP_DIR" ]]; then
+        sudo mkdir -p "$BACKUP_DIR"
+        sudo chown -R "$(id -u):$(id -g)" "$(dirname "$BACKUP_DIR")"
+    fi
+    echo "backup dir: $BACKUP_DIR"
+}
+
+install_cron() {
+    local current new
+    current="$(crontab -l 2>/dev/null || true)"
+
+    # Drop any previous managed block, and retire the old daily container-only
+    # healthcheck -- server-watchdog.sh covers it and much more, hourly.
+    new="$(printf '%s\n' "$current" \
+        | sed "/$(escape "$BEGIN_MARK")/,/$(escape "$END_MARK")/d" \
+        | grep -v 'backend_healthcheck.sh' || true)"
+
+    new+="
+$BEGIN_MARK
+# Hourly: margins, not liveness. See ops/server-watchdog.sh.
+7 * * * * $DEST_DIR/server-watchdog.sh >> $LOG_DIR/watchdog.log 2>&1
+# Nightly 02:30: dump + verify + rotate.
+30 2 * * * $DEST_DIR/pg-backup.sh >> $LOG_DIR/pg-backup.log 2>&1
+# Sunday 04:00: prove the newest dump actually restores.
+0 4 * * 0 $DEST_DIR/pg-restore-test.sh >> $LOG_DIR/pg-restore-test.log 2>&1
+$END_MARK"
+
+    printf '%s\n' "$new" | crontab -
+    echo "cron block written"
+}
+
+uninstall() {
+    local current
+    current="$(crontab -l 2>/dev/null || true)"
+    printf '%s\n' "$current" \
+        | sed "/$(escape "$BEGIN_MARK")/,/$(escape "$END_MARK")/d" \
+        | crontab -
+    echo "cron block removed (scripts and backups left in place)"
+}
+
+verify() {
+    local script ok=1
+    for script in pg-backup.sh pg-restore-test.sh server-watchdog.sh caddy-reload.sh; do
+        bash -n "$DEST_DIR/$script" || { echo "SYNTAX ERROR in $script" >&2; ok=0; }
+    done
+    (( ok )) || exit 1
+    echo "syntax check passed"
+}
+
+# sed treats / and & specially; marker text contains neither today, but escaping
+# keeps this from breaking silently if the markers are ever edited.
+escape() { printf '%s' "$1" | sed 's/[\/&]/\\&/g'; }
+
+main "$@"

--- a/ops/pg-backup.sh
+++ b/ops/pg-backup.sh
@@ -29,7 +29,7 @@ STAMP_FILE="${STAMP_FILE:-$BACKUP_DIR/.last-success}"
 main() {
     require_cmd docker flock
 
-    hold_lock /var/lock/pg-backup.lock
+    hold_lock pg-backup
 
     mkdir -p "$BACKUP_DIR"
 

--- a/ops/pg-backup.sh
+++ b/ops/pg-backup.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+#
+# Nightly PostgreSQL backup.
+#
+# Dumps the application database to BACKUP_DIR in pg_dump's custom format, then
+# rotates old dumps. Credentials are never passed in: pg_dump runs inside the
+# database container and reads POSTGRES_USER/POSTGRES_DB from the environment
+# compose already gave it, so no secret ever reaches this script, the cron entry,
+# or the process list.
+#
+# Usage:  pg-backup.sh
+# Cron:   30 2 * * *  /home/rocky/ops/pg-backup.sh >> /home/rocky/logs/pg-backup.log 2>&1
+
+set -euo pipefail
+
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/common.sh"
+
+DB_CONTAINER="${DB_CONTAINER:-backend-db-1}"
+BACKUP_DIR="${BACKUP_DIR:-/mnt/docker-data/backups/postgres}"
+RETENTION_DAYS="${RETENTION_DAYS:-14}"
+# Never rotate below this many dumps, however old they are. Retention by age
+# alone would wipe every backup after a fortnight of the job failing unnoticed.
+MIN_KEEP="${MIN_KEEP:-7}"
+# Refuse to start a dump that could fill the disk and take the database with it.
+MIN_FREE_MB="${MIN_FREE_MB:-1024}"
+
+STAMP_FILE="${STAMP_FILE:-$BACKUP_DIR/.last-success}"
+
+main() {
+    require_cmd docker flock
+
+    hold_lock /var/lock/pg-backup.lock
+
+    mkdir -p "$BACKUP_DIR"
+
+    local free_mb
+    free_mb="$(df -Pm "$BACKUP_DIR" | awk 'NR==2 {print $4}')"
+    if (( free_mb < MIN_FREE_MB )); then
+        fail "only ${free_mb} MB free on $BACKUP_DIR (need ${MIN_FREE_MB} MB); refusing to dump"
+    fi
+
+    if ! docker inspect -f '{{.State.Running}}' "$DB_CONTAINER" 2>/dev/null | grep -q true; then
+        fail "database container $DB_CONTAINER is not running"
+    fi
+
+    local stamp target tmp
+    stamp="$(date -u '+%Y%m%dT%H%M%SZ')"
+    target="$BACKUP_DIR/backend_db-$stamp.dump"
+    tmp="$target.partial"
+
+    log "dumping $DB_CONTAINER -> $target"
+
+    # A dump that dies halfway leaves a truncated file. Write to .partial and only
+    # promote it to a real backup name once it has been proven restorable, so the
+    # directory never contains a file that looks like a backup but is not one.
+    if ! docker exec "$DB_CONTAINER" sh -c \
+        'pg_dump -U "$POSTGRES_USER" -d "$POSTGRES_DB" -Fc' > "$tmp"; then
+        rm -f "$tmp"
+        fail "pg_dump failed for $DB_CONTAINER"
+    fi
+
+    if ! verify_dump "$tmp"; then
+        rm -f "$tmp"
+        fail "dump did not pass verification; discarded"
+    fi
+
+    sync -f "$tmp" 2>/dev/null || true
+    mv "$tmp" "$target"
+    chmod 600 "$target"
+
+    local size
+    size="$(du -h "$target" | cut -f1)"
+    log "backup ok: $target ($size)"
+
+    printf '%s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" > "$STAMP_FILE"
+
+    rotate
+}
+
+# A dump is only a backup if pg_restore can read its table of contents. This
+# catches truncation, an out-of-disk kill, and a corrupted stream.
+verify_dump() {
+    local file="$1"
+    local entries
+
+    entries="$(docker run --rm -i postgres:16-alpine pg_restore --list < "$file" 2>/dev/null | grep -c ';' || true)"
+
+    if [[ -z "$entries" ]] || (( entries < 1 )); then
+        log "verification failed: pg_restore listed no entries" >&2
+        return 1
+    fi
+
+    log "verified: $entries TOC entries readable"
+}
+
+rotate() {
+    local -a dumps
+    mapfile -t dumps < <(find "$BACKUP_DIR" -maxdepth 1 -name 'backend_db-*.dump' -printf '%T@ %p\n' \
+        | sort -rn | cut -d' ' -f2-)
+
+    local total=${#dumps[@]}
+    if (( total <= MIN_KEEP )); then
+        log "rotation: $total dumps, keeping all (floor is $MIN_KEEP)"
+        return 0
+    fi
+
+    local removed=0 i path age_days
+    for (( i = MIN_KEEP; i < total; i++ )); do
+        path="${dumps[$i]}"
+        age_days=$(( ( $(date +%s) - $(stat -c %Y "$path") ) / 86400 ))
+        if (( age_days >= RETENTION_DAYS )); then
+            rm -f "$path"
+            (( ++removed ))
+        fi
+    done
+
+    log "rotation: $total dumps, removed $removed older than ${RETENTION_DAYS}d"
+}
+
+fail() {
+    local msg="$1"
+    log "ERROR: $msg" >&2
+    send_notification ":rotating_light: **Backup feilet** på $(hostname)
+
+$msg
+
+Ingen ny backup ble tatt. Siste vellykkede: $(cat "$STAMP_FILE" 2>/dev/null || echo 'ukjent')" || true
+    exit 1
+}
+
+main "$@"

--- a/ops/pg-restore-test.sh
+++ b/ops/pg-restore-test.sh
@@ -23,14 +23,18 @@ PG_IMAGE="${PG_IMAGE:-postgres:16-alpine}"
 SCRATCH_NAME="restore-test-$$"
 READY_TIMEOUT="${READY_TIMEOUT:-60}"
 
+# A fixed name in /tmp is a symlink someone else can plant; mktemp is not.
+ERR_FILE="$(mktemp)"
+
 cleanup() {
     docker rm -f "$SCRATCH_NAME" >/dev/null 2>&1 || true
+    rm -f "$ERR_FILE"
 }
 trap cleanup EXIT
 
 main() {
     require_cmd docker flock
-    hold_lock /var/lock/pg-restore-test.lock
+    hold_lock pg-restore-test
 
     local dump
     dump="${1:-$(newest_dump)}"
@@ -42,12 +46,12 @@ main() {
     wait_ready
 
     if ! docker exec -i "$SCRATCH_NAME" \
-        pg_restore -U postgres -d postgres --no-owner --no-privileges < "$dump" 2>/tmp/restore-test.err; then
+        pg_restore -U postgres -d postgres --no-owner --no-privileges < "$dump" 2>"$ERR_FILE"; then
         # pg_restore warns about things that do not matter here (missing roles,
         # extension ownership). Only a hard failure to produce tables is fatal,
         # so fall through to the table count rather than trusting the exit code.
         log "pg_restore exited non-zero; checking whether the schema arrived anyway"
-        log "$(tail -5 /tmp/restore-test.err 2>/dev/null || true)"
+        log "$(tail -5 "$ERR_FILE" 2>/dev/null || true)"
     fi
 
     local restored expected

--- a/ops/pg-restore-test.sh
+++ b/ops/pg-restore-test.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+#
+# Weekly restore verification.
+#
+# Restores the newest dump into a throwaway PostgreSQL container and checks that
+# the schema actually arrives, then destroys it. `pg_dump` exiting 0 only proves a
+# file was written; this proves the file can be turned back into a database, which
+# is the only property anyone actually wants from a backup.
+#
+# The scratch container is created with --network none and no published ports, so
+# it is unreachable from the host and from the other containers while it exists.
+#
+# Usage:  pg-restore-test.sh [path/to/dump]
+# Cron:   0 4 * * 0  /home/rocky/ops/pg-restore-test.sh >> /home/rocky/logs/pg-restore-test.log 2>&1
+
+set -euo pipefail
+
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/common.sh"
+
+BACKUP_DIR="${BACKUP_DIR:-/mnt/docker-data/backups/postgres}"
+DB_CONTAINER="${DB_CONTAINER:-backend-db-1}"
+PG_IMAGE="${PG_IMAGE:-postgres:16-alpine}"
+SCRATCH_NAME="restore-test-$$"
+READY_TIMEOUT="${READY_TIMEOUT:-60}"
+
+cleanup() {
+    docker rm -f "$SCRATCH_NAME" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+main() {
+    require_cmd docker flock
+    hold_lock /var/lock/pg-restore-test.lock
+
+    local dump
+    dump="${1:-$(newest_dump)}"
+    [[ -n "$dump" && -f "$dump" ]] || fail "no dump found in $BACKUP_DIR"
+
+    log "restore test using $dump"
+
+    start_scratch
+    wait_ready
+
+    if ! docker exec -i "$SCRATCH_NAME" \
+        pg_restore -U postgres -d postgres --no-owner --no-privileges < "$dump" 2>/tmp/restore-test.err; then
+        # pg_restore warns about things that do not matter here (missing roles,
+        # extension ownership). Only a hard failure to produce tables is fatal,
+        # so fall through to the table count rather than trusting the exit code.
+        log "pg_restore exited non-zero; checking whether the schema arrived anyway"
+        log "$(tail -5 /tmp/restore-test.err 2>/dev/null || true)"
+    fi
+
+    local restored expected
+    restored="$(count_tables "$SCRATCH_NAME" postgres)"
+    expected="$(count_tables "$DB_CONTAINER" '' || echo 0)"
+
+    log "tables restored=$restored, live=$expected"
+
+    if (( restored < 1 )); then
+        fail "restore produced no tables from $dump"
+    fi
+
+    if (( expected > 0 && restored < expected )); then
+        fail "restore is incomplete: $restored of $expected tables from $(basename "$dump")"
+    fi
+
+    log "restore test passed: $restored tables from $(basename "$dump")"
+}
+
+newest_dump() {
+    find "$BACKUP_DIR" -maxdepth 1 -name 'backend_db-*.dump' -printf '%T@ %p\n' 2>/dev/null \
+        | sort -rn | head -1 | cut -d' ' -f2-
+}
+
+start_scratch() {
+    # Password is random and never leaves this function; nothing connects to this
+    # container over the network anyway.
+    docker run -d --rm \
+        --name "$SCRATCH_NAME" \
+        --network none \
+        -e POSTGRES_PASSWORD="$(openssl rand -hex 16)" \
+        "$PG_IMAGE" >/dev/null || fail "could not start scratch container"
+}
+
+wait_ready() {
+    local waited=0
+    until docker exec "$SCRATCH_NAME" pg_isready -U postgres -q 2>/dev/null; do
+        sleep 2
+        waited=$(( waited + 2 ))
+        if (( waited >= READY_TIMEOUT )); then
+            fail "scratch database never became ready within ${READY_TIMEOUT}s"
+        fi
+    done
+    log "scratch database ready after ${waited}s"
+}
+
+# count_tables <container> <db-or-empty-to-use-container-env>
+count_tables() {
+    local container="$1" db="$2"
+    local sql="SELECT count(*) FROM information_schema.tables WHERE table_schema='public';"
+
+    if [[ -n "$db" ]]; then
+        docker exec "$container" psql -U postgres -d "$db" -tAc "$sql" 2>/dev/null | tr -d '[:space:]'
+    else
+        docker exec "$container" sh -c \
+            "psql -U \"\$POSTGRES_USER\" -d \"\$POSTGRES_DB\" -tAc \"$sql\"" 2>/dev/null | tr -d '[:space:]'
+    fi
+}
+
+fail() {
+    local msg="$1"
+    log "ERROR: $msg" >&2
+    send_notification ":test_tube: **Restore-test feilet** på $(hostname)
+
+$msg
+
+Backupene kan ikke antas å være gjenopprettbare før dette er undersøkt." || true
+    exit 1
+}
+
+main "$@"

--- a/ops/server-watchdog.sh
+++ b/ops/server-watchdog.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+#
+# Hourly server watchdog.
+#
+# Supersedes backend_healthcheck.sh, which only asked "are the containers up?"
+# once a day. Every incident on 2026-07-25 passed that test while it happened:
+# the Caddyfile was invalid for hours, 64k systemd unit tombstones ate 890 MB of
+# RAM, a TLS certificate had been dead for 77 days, and the root disk crept to
+# 80%. Containers were up and every endpoint returned 200 throughout.
+#
+# So this measures margins, not liveness. Each check reports how much room is
+# left before something breaks, and the alert fires while there is still time to
+# act.
+#
+# Usage:  server-watchdog.sh [--dry-run]
+# Cron:   7 * * * *  /home/rocky/ops/server-watchdog.sh >> /home/rocky/logs/watchdog.log 2>&1
+
+set -euo pipefail
+
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/common.sh"
+
+DISK_WARN_PCT="${DISK_WARN_PCT:-85}"
+MEM_MIN_MB="${MEM_MIN_MB:-250}"
+PID1_MAX_MB="${PID1_MAX_MB:-200}"
+UNITS_MAX="${UNITS_MAX:-1000}"
+CERT_MIN_DAYS="${CERT_MIN_DAYS:-14}"
+BACKUP_MAX_AGE_H="${BACKUP_MAX_AGE_H:-30}"
+
+CONTAINER_PATTERN="${CONTAINER_PATTERN:-^backend-.*-1$}"
+HEALTH_URLS="${HEALTH_URLS:-https://api.vuhnger.dev/site/health https://api.vuhnger.dev/projects/health https://api.vuhnger.dev/strava/health https://api.vuhnger.dev/wakatime/health https://analytics.vuhnger.dev}"
+CERT_HOSTS="${CERT_HOSTS:-api.vuhnger.dev analytics.vuhnger.dev}"
+BACKUP_STAMP="${BACKUP_STAMP:-/mnt/docker-data/backups/postgres/.last-success}"
+CADDYFILE="${CADDYFILE:-/etc/caddy/Caddyfile}"
+
+STATE_DIR="${STATE_DIR:-$HOME/.local/state/backend-watchdog}"
+STATE_FILE="$STATE_DIR/last-alert"
+# A condition that stays broken should not produce 24 identical alerts a day.
+# Re-alert at most this often while nothing changes.
+REMIND_HOURS="${REMIND_HOURS:-12}"
+
+DRY_RUN=0
+PROBLEMS=()
+
+problem() { PROBLEMS+=("$1"); }
+
+main() {
+    [[ "${1:-}" == "--dry-run" ]] && DRY_RUN=1
+
+    require_cmd docker curl awk
+    mkdir -p "$STATE_DIR"
+
+    check_containers
+    check_endpoints
+    check_disk
+    check_memory
+    check_systemd
+    check_caddy
+    check_certs
+    check_backup
+
+    report
+}
+
+# ---------------------------------------------------------------------------
+# checks
+# ---------------------------------------------------------------------------
+
+check_containers() {
+    local -a names
+    mapfile -t names < <(docker ps -a --format '{{.Names}}' 2>/dev/null | grep -E "$CONTAINER_PATTERN" || true)
+
+    if (( ${#names[@]} == 0 )); then
+        problem "Ingen containere matcher '$CONTAINER_PATTERN' -- stacken er nede eller omdøpt"
+        return
+    fi
+
+    local name state health
+    for name in "${names[@]}"; do
+        state="$(docker inspect -f '{{.State.Status}}' "$name" 2>/dev/null || echo unknown)"
+        health="$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}n/a{{end}}' "$name" 2>/dev/null || echo unknown)"
+
+        if [[ "$state" != "running" ]]; then
+            problem "Container $name: state=$state"
+        elif [[ "$health" != "n/a" && "$health" != "healthy" ]]; then
+            problem "Container $name: health=$health"
+        fi
+    done
+}
+
+# Tests through Caddy over the public name, not against the container port. A
+# container can be perfectly healthy while the edge in front of it is broken --
+# which is exactly the failure that went unnoticed.
+check_endpoints() {
+    local url code
+    for url in $HEALTH_URLS; do
+        code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 "$url" 2>/dev/null || echo 000)"
+        [[ "$code" == "200" ]] || problem "Endepunkt $url svarte $code"
+    done
+}
+
+check_disk() {
+    local mount pct
+    for mount in / /mnt/docker-data; do
+        [[ -d "$mount" ]] || continue
+        pct="$(df -P "$mount" 2>/dev/null | awk 'NR==2 {gsub(/%/,"",$5); print $5}')"
+        [[ -n "$pct" ]] || continue
+        (( pct >= DISK_WARN_PCT )) && problem "Disk $mount er ${pct}% full (grense ${DISK_WARN_PCT}%)"
+    done
+    return 0
+}
+
+check_memory() {
+    local avail_mb swap_used_mb swap_total_mb
+    avail_mb="$(awk '/MemAvailable/ {print int($2/1024)}' /proc/meminfo)"
+    swap_total_mb="$(awk '/SwapTotal/ {print int($2/1024)}' /proc/meminfo)"
+    swap_used_mb=$(( swap_total_mb - $(awk '/SwapFree/ {print int($2/1024)}' /proc/meminfo) ))
+
+    (( avail_mb < MEM_MIN_MB )) && problem "Kun ${avail_mb} MB ledig minne (grense ${MEM_MIN_MB} MB)"
+
+    # No swap at all is how a fork failure turns into an outage rather than a
+    # slowdown; that is what happened here.
+    (( swap_total_mb == 0 )) && problem "Ingen swap konfigurert"
+
+    if (( swap_total_mb > 0 )) && (( swap_used_mb * 100 / swap_total_mb > 75 )); then
+        problem "Swap er ${swap_used_mb}/${swap_total_mb} MB i bruk -- maskinen bytter tungt"
+    fi
+    return 0
+}
+
+# The 2026-07-25 leak in one check: PID 1 grew to 890 MB because failed transient
+# units are retained in memory forever. Both numbers are flat on a healthy box.
+check_systemd() {
+    local pid1_mb units failed
+    pid1_mb=$(( $(awk '{print $1}' <<< "$(ps -o rss= -p 1)") / 1024 ))
+    units="$(systemctl list-units --all --plain --no-pager 2>/dev/null | wc -l)"
+    failed="$(systemctl --failed --plain --no-pager 2>/dev/null | grep -c '\.service' || true)"
+
+    (( pid1_mb > PID1_MAX_MB )) && problem "systemd (PID 1) bruker ${pid1_mb} MB (normalt ~15 MB) -- kjør 'systemctl reset-failed' så 'daemon-reexec'"
+    (( units > UNITS_MAX )) && problem "${units} systemd-units lastet (grense ${UNITS_MAX}) -- gravsteiner hoper seg opp"
+    (( failed > 5 )) && problem "${failed} feilede systemd-units"
+    return 0
+}
+
+# Catches the exact failure that started all of this: a Caddyfile that no longer
+# parses while caddy happily serves its last good config from memory.
+check_caddy() {
+    command -v caddy >/dev/null 2>&1 || return 0
+    [[ -f "$CADDYFILE" ]] || return 0
+
+    caddy validate --adapter caddyfile --config "$CADDYFILE" >/dev/null 2>&1 \
+        || problem "$CADDYFILE er UGYLDIG -- kjøres fra minnet nå, men neste restart tar ned alt"
+    return 0
+}
+
+check_certs() {
+    local host expiry_date expiry_epoch days
+    for host in $CERT_HOSTS; do
+        expiry_date="$(echo | timeout 15 openssl s_client -connect "$host:443" -servername "$host" 2>/dev/null \
+            | openssl x509 -noout -enddate 2>/dev/null | cut -d= -f2)"
+
+        if [[ -z "$expiry_date" ]]; then
+            problem "Fikk ikke hentet sertifikat for $host"
+            continue
+        fi
+
+        expiry_epoch="$(date -d "$expiry_date" +%s 2>/dev/null || echo 0)"
+        (( expiry_epoch == 0 )) && continue
+        days=$(( (expiry_epoch - $(date +%s)) / 86400 ))
+
+        (( days < CERT_MIN_DAYS )) && problem "Sertifikatet for $host utløper om ${days} dager"
+    done
+    return 0
+}
+
+check_backup() {
+    if [[ ! -s "$BACKUP_STAMP" ]]; then
+        problem "Ingen vellykket backup registrert ($BACKUP_STAMP mangler)"
+        return 0
+    fi
+
+    local last_epoch age_h
+    last_epoch="$(date -d "$(cat "$BACKUP_STAMP")" +%s 2>/dev/null || echo 0)"
+    if (( last_epoch == 0 )); then
+        problem "Kan ikke tolke tidsstempelet i $BACKUP_STAMP"
+        return 0
+    fi
+
+    age_h=$(( ( $(date +%s) - last_epoch ) / 3600 ))
+    (( age_h > BACKUP_MAX_AGE_H )) && problem "Siste vellykkede backup er ${age_h} timer gammel (grense ${BACKUP_MAX_AGE_H}t)"
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# reporting
+# ---------------------------------------------------------------------------
+
+report() {
+    local count=${#PROBLEMS[@]}
+
+    if (( count == 0 )); then
+        log "alle sjekker OK"
+        # Only announce recovery if there was something to recover from.
+        if [[ -s "$STATE_FILE" ]]; then
+            notify ":white_check_mark: **Alt friskt igjen** på $(hostname)"
+            rm -f "$STATE_FILE"
+        fi
+        return 0
+    fi
+
+    local body
+    body="$(printf '%s\n' "${PROBLEMS[@]}")"
+    log "$count problem(er):"
+    printf -- '- %s\n' "${PROBLEMS[@]}"
+
+    if (( DRY_RUN )); then
+        log "(dry-run: varsler ikke)"
+        return 0
+    fi
+
+    # Suppress repeats of an identical, still-unresolved condition so the channel
+    # stays worth reading. A change in the problem set always alerts immediately.
+    local fingerprint previous last_epoch
+    fingerprint="$(printf '%s' "$body" | cksum | cut -d' ' -f1)"
+    previous=""
+    last_epoch=0
+    if [[ -s "$STATE_FILE" ]]; then
+        previous="$(head -1 "$STATE_FILE")"
+        last_epoch="$(tail -1 "$STATE_FILE")"
+    fi
+
+    if [[ "$fingerprint" == "$previous" ]] \
+        && (( ( $(date +%s) - last_epoch ) < REMIND_HOURS * 3600 )); then
+        log "uendret siden forrige varsel; hopper over (påminnelse hver ${REMIND_HOURS}t)"
+        return 0
+    fi
+
+    notify ":warning: **${count} problem(er)** på $(hostname)
+
+$body"
+
+    printf '%s\n%s\n' "$fingerprint" "$(date +%s)" > "$STATE_FILE"
+}
+
+notify() {
+    send_notification "$1" || log "ADVARSEL: kunne ikke levere varselet" >&2
+}
+
+main "$@"


### PR DESCRIPTION
Four things broke on the NREC host on 2026-07-25, and the monitoring in place reported a healthy system throughout every one of them:

| What happened | Why nothing noticed |
|---|---|
| The Caddyfile was syntactically invalid for hours | Caddy keeps serving its last good config from memory. `systemctl is-active` said `active`; every endpoint returned 200. Only a reboot would have surfaced it, by taking every site down at once. |
| systemd (PID 1) grew to 890 MB | 64,576 failed `systemd-coredump@*` unit tombstones retained in RAM. Eventually systemd could not fork and every `systemctl` verb failed with ENOMEM. |
| `ruta.vuhnger.dev` served no certificate for 77 days | Nothing checked certificate expiry. |
| The root disk reached 80% | Nothing checked disk, and a 39 GB second volume sat mounted and empty. |

There were also **no database backups at all**.

## What this adds

| Script | Schedule | What it does |
|---|---|---|
| `server-watchdog.sh` | hourly, :07 | Containers, public endpoints through Caddy, disk, memory, swap, PID 1 RSS, unit counts, Caddyfile validity, TLS expiry, backup age |
| `pg-backup.sh` | nightly, 02:30 | `pg_dump -Fc` to `/mnt/docker-data/backups/postgres`, verified before being accepted, then rotated |
| `pg-restore-test.sh` | Sundays, 04:00 | Restores the newest dump into a throwaway container and counts the tables |
| `caddy-reload.sh` | manual | validate → reload → verify against the admin API → commit to `/etc/caddy` |

## Design

- **Margins, not liveness.** The common shape of every incident was silent degradation, so each check reports how much room is left before something breaks, while there is still time to act.
- **Backups are verified, not assumed.** `pg_dump` exiting 0 only proves a file was written. Each dump is written to `.partial`, checked with `pg_restore --list`, and only then renamed — so the directory can never hold a file that looks like a backup but is not one. The weekly job restores one for real.
- **Rotation has a floor.** `MIN_KEEP` (7) is never crossed regardless of age, so a job failing unnoticed for a fortnight cannot erase the history it stopped adding to.
- **Credentials stay in the container.** `pg_dump` runs via `docker exec` and reads `POSTGRES_USER`/`POSTGRES_DB` from the environment compose already provided. No secret reaches these scripts, the cron entries, or `ps`. The Discord webhook is read from `~/.config` at runtime.
- **Alerts deduplicate.** An unchanged condition re-alerts at most every `REMIND_HOURS` (12); any change in the problem set alerts immediately.
- **`caddy-reload.sh` falls back to the admin API,** because `systemctl reload` needs systemd to fork — exactly what fails under the memory pressure you most want to fix.
- Every threshold is an environment variable with a default. Nothing is hardcoded.

## Not deployed automatically

`deploy.yml` does not touch `ops/`. Installation is explicit and idempotent:

```bash
ssh nrec && cd ~/backend && git pull && ops/install.sh
```

`install.sh` writes its cron entries inside a marked block, so re-running rewrites only that block and leaves the hand-written strava/wakatime entries untouched. It retires the old daily `backend_healthcheck.sh` line, which the watchdog supersedes.

## Verification

`shellcheck -x` clean at default severity (exit 0, no output) on all six files.