### PR TITLE
fix(strava): pass heatmap privacy settings into the container

### DIFF
--- a/apps/shared/config.py
+++ b/apps/shared/config.py
@@ -8,8 +8,9 @@ config lives in one typed place.
 """
 
 from functools import lru_cache
+from typing import Any
 
-from pydantic import field_validator
+from pydantic import field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,6 +19,23 @@ class Settings(BaseSettings):
     # env is populated (docker compose `env_file: .env` / `environment:`), so
     # Settings doesn't parse .env itself — which also keeps tests hermetic.
     model_config = SettingsConfigDict(extra="ignore")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _blank_means_unset(cls, data: Any) -> Any:
+        """Treat an empty environment variable as absent.
+
+        Compose expands an unset ``${VAR}`` to the empty string rather than
+        omitting it, so a value merely missing from the host .env arrives here
+        as ``""``. For the str fields that is harmless, but for a numeric one
+        pydantic raises at import time — and because this module builds its
+        singleton at import, that turns a forgotten .env line into a
+        crash-looping container instead of the intended graceful degradation.
+        Dropping blanks lets every field fall back to its declared default.
+        """
+        if isinstance(data, dict):
+            return {k: v for k, v in data.items() if not (isinstance(v, str) and v == "")}
+        return data
 
     # Runtime
     environment: str = "development"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,14 @@ services:
       STRAVA_CLIENT_SECRET: ${STRAVA_CLIENT_SECRET}
       STRAVA_REDIRECT_URI: ${STRAVA_REDIRECT_URI}
 
+      # Heatmap privacy clipping. Without the coordinate /strava/heatmap refuses
+      # to serve (503) rather than publish untrimmed tracks, so these have to be
+      # listed here explicitly -- this service has no env_file, which means the
+      # host .env only reaches the container through the names spelled out below.
+      STRAVA_HOME_LAT: ${STRAVA_HOME_LAT}
+      STRAVA_HOME_LNG: ${STRAVA_HOME_LNG}
+      STRAVA_PRIVACY_RADIUS_M: ${STRAVA_PRIVACY_RADIUS_M:-500}
+
       # Frontend integration
       FRONTEND_URL: ${FRONTEND_URL:-https://vuhnger.dev}
     depends_on:

--- a/tests/test_config_env_wiring.py
+++ b/tests/test_config_env_wiring.py
@@ -48,6 +48,17 @@ def test_heatmap_settings_are_passed_into_the_container(strava_service_env, var)
         f"block, so it can never reach the process"
     )
 
+    # Presence alone isn't enough: the entry has to actually substitute the
+    # host variable of the same name. A hardcoded literal or a typo in the
+    # ${...} spelling would satisfy the check above while still starving the
+    # container. Prefix rather than equality, since a `:-default` suffix is
+    # legitimate.
+    value = strava_service_env[var]
+    assert isinstance(value, str) and value.startswith(f"${{{var}"), (
+        f"{var} is listed but resolves to {value!r} instead of substituting "
+        f"the host variable of the same name"
+    )
+
 
 def _settings_with_env(monkeypatch, **env: str) -> Settings:
     """Build Settings from real process env.
@@ -56,7 +67,14 @@ def _settings_with_env(monkeypatch, **env: str) -> Settings:
     field names, so the SCREAMING_CASE spelling would be silently discarded as
     an extra and every assertion below would pass against defaults instead of
     against the value under test.
+
+    Every heatmap variable is cleared first. setenv only overrides what a test
+    names, so a developer with STRAVA_HOME_LNG exported in their shell would
+    otherwise turn the half-configured case into a fully configured one and the
+    test would pass while asserting the opposite of what it claims.
     """
+    for key in HEATMAP_ENV_VARS:
+        monkeypatch.delenv(key, raising=False)
     for key, value in env.items():
         monkeypatch.setenv(key, value)
     return Settings()

--- a/tests/test_config_env_wiring.py
+++ b/tests/test_config_env_wiring.py
@@ -1,0 +1,110 @@
+"""Guards on how host configuration actually reaches the app.
+
+Two failure modes are covered, both of which shipped to production once:
+
+1. A setting exists in ``Settings`` but is never listed in the compose
+   service's ``environment:`` block, so the host .env can't reach the
+   container at all.
+2. A variable is listed in compose but missing from the host .env, so Compose
+   expands it to ``""`` and pydantic rejects it at import time.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from apps.shared.config import Settings
+
+COMPOSE_FILE = Path(__file__).resolve().parents[1] / "docker-compose.yml"
+
+# Settings the heatmap depends on. Absent from the container's environment the
+# endpoint can only answer 503, which is exactly the outage this test exists to
+# prevent from recurring silently.
+HEATMAP_ENV_VARS = (
+    "STRAVA_HOME_LAT",
+    "STRAVA_HOME_LNG",
+    "STRAVA_PRIVACY_RADIUS_M",
+)
+
+
+@pytest.fixture(scope="module")
+def strava_service_env() -> dict[str, str]:
+    compose = yaml.safe_load(COMPOSE_FILE.read_text())
+    service = compose["services"]["strava-api"]
+    # A service using env_file passes the whole file through and needs no
+    # allowlist; this assertion pins the assumption the test rests on.
+    assert "env_file" not in service, (
+        "strava-api gained an env_file; the explicit allowlist below is no "
+        "longer the only path for host config and this test needs rethinking"
+    )
+    return service["environment"]
+
+
+@pytest.mark.parametrize("var", HEATMAP_ENV_VARS)
+def test_heatmap_settings_are_passed_into_the_container(strava_service_env, var):
+    assert var in strava_service_env, (
+        f"{var} is read by Settings but not listed in strava-api's environment: "
+        f"block, so it can never reach the process"
+    )
+
+
+def _settings_with_env(monkeypatch, **env: str) -> Settings:
+    """Build Settings from real process env.
+
+    Deliberately not ``Settings(**kwargs)``: init kwargs are matched against
+    field names, so the SCREAMING_CASE spelling would be silently discarded as
+    an extra and every assertion below would pass against defaults instead of
+    against the value under test.
+    """
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    return Settings()
+
+
+def test_blank_coordinates_degrade_to_unset_rather_than_crashing(monkeypatch):
+    # What Compose sends for a ${VAR} that the host .env doesn't define.
+    settings = _settings_with_env(
+        monkeypatch,
+        STRAVA_HOME_LAT="",
+        STRAVA_HOME_LNG="",
+        STRAVA_PRIVACY_RADIUS_M="",
+    )
+
+    assert settings.strava_home_lat is None
+    assert settings.strava_home_lng is None
+    assert settings.strava_home_coordinate is None
+    # Blank must fall back to the declared default, not to zero -- a zero radius
+    # would disable clipping entirely.
+    assert settings.strava_privacy_radius_m == 500.0
+
+
+def test_half_configured_coordinate_is_still_treated_as_unconfigured(monkeypatch):
+    settings = _settings_with_env(
+        monkeypatch, STRAVA_HOME_LAT="59.939383", STRAVA_HOME_LNG=""
+    )
+
+    assert settings.strava_home_lat == 59.939383
+    assert settings.strava_home_coordinate is None
+
+
+def test_blank_does_not_mask_a_genuinely_invalid_value(monkeypatch):
+    with pytest.raises(ValueError, match="between -90 and 90"):
+        _settings_with_env(monkeypatch, STRAVA_HOME_LAT="91.0")
+
+
+def test_blank_does_not_mask_an_unparseable_value(monkeypatch):
+    with pytest.raises(ValueError, match="valid number"):
+        _settings_with_env(monkeypatch, STRAVA_HOME_LNG="not-a-number")
+
+
+def test_real_values_still_parse(monkeypatch):
+    settings = _settings_with_env(
+        monkeypatch,
+        STRAVA_HOME_LAT="59.939383",
+        STRAVA_HOME_LNG="10.649669",
+        STRAVA_PRIVACY_RADIUS_M="750",
+    )
+
+    assert settings.strava_home_coordinate == (59.939383, 10.649669)
+    assert settings.strava_privacy_radius_m == 750.0


### PR DESCRIPTION
## Problem

`/strava/heatmap` returned 503 in production even with `STRAVA_HOME_LAT` and `STRAVA_HOME_LNG` set in the host `.env`:

```
$ curl -s https://api.vuhnger.dev/strava/heatmap?activity_type=Run
{"detail":"Heatmap is unavailable: privacy clipping is not configured."}
```

`strava-api` declares an explicit `environment:` block and has no `env_file`. The host `.env` is therefore consumed by Compose for `${...}` substitution only — a variable not named in the block never reaches the process. The three heatmap settings were added to `Settings` and to `.env.example`, but never wired into compose.

## Changes

**`docker-compose.yml`** — add `STRAVA_HOME_LAT`, `STRAVA_HOME_LNG` and `STRAVA_PRIVACY_RADIUS_M` to the `strava-api` environment block.

**`apps/shared/config.py`** — treat a blank environment variable as unset.

Compose expands an unset `${VAR}` to `""` rather than omitting it. Without this, a forgotten `.env` line reaches pydantic as an empty string:

```
pydantic_core.ValidationError: 2 validation errors for Settings
strava_home_lat
  Input should be a valid number, unable to parse string as a number [input_value='']
```

`Settings` builds its singleton at module import, so that failure kills the process before uvicorn binds — turning a missing config line into a crash-looping container instead of the 503 the endpoint is designed to return. The fix is a single `mode="before"` model validator rather than per-field validators, since the same hazard applies to every numeric setting fed through a bare `${VAR}`.

Invalid values are unaffected and still fail loudly: only blanks degrade.

## Tests

`tests/test_config_env_wiring.py` covers both failure modes:

- every heatmap setting is present in the compose block **and** actually substitutes the host variable of the same name (presence alone would pass on a hardcoded literal or a typo'd `${...}`)
- blank values fall back to declared defaults; a blank radius yields 500, not 0, since a zero radius would disable clipping entirely
- a half-configured coordinate is still treated as unconfigured
- out-of-range and unparseable values still raise

The helper builds `Settings` from real process env rather than init kwargs — SCREAMING_CASE kwargs are discarded as extras, which made the first draft of these tests pass against defaults instead of the values under test.

## Verification

```
147 passed, 2 skipped
ruff: All checks passed
mypy: Success: no issues found in 20 source files
docker compose config -> STRAVA_HOME_LAT / STRAVA_HOME_LNG / STRAVA_PRIVACY_RADIUS_M all render
CodeRabbit: 2 minor findings, both applied
```

## After merge

The deploy job runs `git pull` + `docker compose up -d`; the changed compose config recreates `strava-api` automatically. The host `.env` on the server has already been corrected (`STRAVA_HOME_LONG` -> `STRAVA_HOME_LNG`).

A full re-sync is still needed before the heatmap returns data — all 415 runs currently have `summary_polyline` NULL:

```
POST /strava/refresh-data?full=true   (X-API-Key)
```