### PR TITLE
ops: close the CodeRabbit findings, mostly fail-open bugs

### DIFF
--- a/ops/README.md
+++ b/ops/README.md
@@ -71,7 +71,7 @@ The ones worth knowing:
 
 | Variable | Default | Meaning |
 |---|---|---|
-| `DISK_WARN_PCT` | `85` | Alert above this fill level |
+| `DISK_WARN_PCT` | `80` | Alert above this fill level — set to the level the 2026-07-25 incident reached, so the default catches the failure this table's first row describes |
 | `MEM_MIN_MB` | `250` | Alert below this much available memory |
 | `PID1_MAX_MB` | `200` | Alert if systemd exceeds this (normal is ~15 MB) |
 | `UNITS_MAX` | `1000` | Alert on unit-tombstone accumulation |
@@ -97,10 +97,15 @@ in the right one.
 
 ```bash
 ls -lt /mnt/docker-data/backups/postgres/
+
+# Pick one from that listing. Quoted in a variable, because an unquoted
+# <placeholder> pasted into a shell is parsed as a redirection, not a filename.
+DUMP=/mnt/docker-data/backups/postgres/backend_db-20260725T091048Z.dump
+
 docker compose stop strava-api wakatime-api projects-api site-api n8n-api
 docker exec -i backend-db-1 sh -c \
   'pg_restore -U "$POSTGRES_USER" -d "$POSTGRES_DB" --clean --if-exists' \
-  < /mnt/docker-data/backups/postgres/backend_db-<stamp>.dump
+  < "$DUMP"
 docker compose start strava-api wakatime-api projects-api site-api n8n-api
 ```
 
@@ -138,5 +143,8 @@ Three things bite anyone repeating this move:
   `--force-recreate` is what actually applies it. Check with
   `docker inspect <c> --format '{{.HostConfig.LogConfig.Config}}'`.
 
-Verify a move with a `--dry-run --itemize-changes` rsync (must print nothing) rather
-than comparing `du` output, which differs across filesystems and hardlinks.
+Verify a move with a `--dry-run --itemize-changes` rsync, which must emit no
+itemized change lines, rather than comparing `du` output — that differs across
+filesystems and hardlinks and proved useless here (6.4G running vs 2.5G stopped for
+the same tree). Keep `-v`/`--stats` off the verification run: they add a summary to
+otherwise empty output, so an "is this empty?" test would never pass.

--- a/ops/caddy-reload.sh
+++ b/ops/caddy-reload.sh
@@ -70,10 +70,15 @@ reload() {
     # pressure (see ops/README.md). The admin API runs inside the existing caddy
     # process and needs no fork, so it still works when systemctl does not.
     log "systemctl reload failed; falling back to the admin API"
+    # A timeout or refused connection makes curl exit non-zero, which under
+    # `set -e` would kill the script at the assignment -- before the HTTP check
+    # below could say why. Catch the transport failure separately.
     local code
-    code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 30 \
+    if ! code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 30 \
         -X POST -H 'Content-Type: application/json' \
-        --data-binary "@$adapted" "$ADMIN/load")"
+        --data-binary "@$adapted" "$ADMIN/load")"; then
+        die "could not reach the admin API at $ADMIN"
+    fi
 
     [[ "$code" == "200" ]] || die "admin API load returned HTTP $code"
     log "reloaded via admin API"
@@ -91,11 +96,19 @@ verify() {
         die "could not read running config from the admin API"
     }
 
+    # Compare every top-level section the Caddyfile actually declares -- apps, but
+    # also logging and admin -- rather than apps alone, which would call a reload
+    # that changed only logging a success. Sections present solely in the running
+    # config are Caddy's own defaults and would produce false mismatches, so they
+    # are not required to appear in the adapted output.
     if python3 -c '
 import json, sys
 with open(sys.argv[1]) as f: want = json.load(f)
 with open(sys.argv[2]) as f: live = json.load(f)
-sys.exit(0 if want.get("apps") == live.get("apps") else 1)
+missing = [k for k, v in want.items() if live.get(k) != v]
+if missing:
+    print("sections that did not take: " + ", ".join(sorted(missing)), file=sys.stderr)
+sys.exit(1 if missing else 0)
 ' "$adapted" "$live"; then
         log "running config matches $CADDYFILE"
         rm -f "$live"

--- a/ops/common.sh
+++ b/ops/common.sh
@@ -25,7 +25,12 @@ log() {
 }
 
 die() {
-    log "FATAL: $*" >&2
+    local message="FATAL: $*"
+    log "$message" >&2
+    # These scripts run unattended. A fatal error that only reaches a log file
+    # nobody reads is a silent failure -- the exact class of problem they exist
+    # to catch. Never let a failed notification mask the original error.
+    send_notification "$message" || true
     exit 1
 }
 
@@ -44,6 +49,13 @@ send_notification() {
 
     webhook_url="$(<"$WEBHOOK_FILE")"
 
+    # Anything but a plain https URL is either a corrupted file or an attempt to
+    # smuggle extra directives into the curl config below.
+    if [[ "$webhook_url" != https://* || "$webhook_url" == *[\"\\]* ]]; then
+        log "cannot notify: webhook file does not contain a plain https URL" >&2
+        return 1
+    fi
+
     if (( ${#message} > MAX_MESSAGE_CHARS )); then
         message="${message:0:$MAX_MESSAGE_CHARS}"$'\n[...avkortet]'
     fi
@@ -59,9 +71,13 @@ print(json.dumps({"content": os.environ["CONTENT"]}))
         return 1
     }
 
-    curl -fsS --max-time 15 --retry 2 --retry-delay 3 \
-        -H "Content-Type: application/json" \
-        -d "$payload" "$webhook_url" >/dev/null
+    # The URL is the secret, so it must not become a curl argument: argv is world
+    # readable through `ps` and /proc for every user on the box. Feeding it as a
+    # curl config file on stdin keeps it out of the process table entirely.
+    printf 'url = "%s"\n' "$webhook_url" \
+        | curl -fsS --max-time 15 --retry 2 --retry-delay 3 \
+            -H "Content-Type: application/json" \
+            -d "$payload" --config - >/dev/null
 }
 
 # require_cmd <name>...
@@ -83,11 +99,20 @@ LOCK_DIR="${LOCK_DIR:-$HOME/.local/state/backend-ops}"
 hold_lock() {
     local name="$1"
     local lockfile="$LOCK_DIR/$name.lock"
+    local rc=0
 
+    require_cmd flock
     mkdir -p "$LOCK_DIR" || die "cannot create lock directory: $LOCK_DIR"
     exec 9>"$lockfile" || die "cannot open lock file: $lockfile"
-    flock -n 9 || {
-        log "another instance is already running ($lockfile); exiting"
-        exit 0
-    }
+
+    # Give contention its own exit code. A bare `flock -n 9 || exit 0` cannot tell
+    # "another copy is running" from "flock is broken", so any operational failure
+    # would look like a healthy skip and the job would quietly do nothing -- every
+    # night, without a single alert.
+    flock -n --conflict-exit-code 66 9 || rc=$?
+    case "$rc" in
+        0)  ;;
+        66) log "another instance is already running ($lockfile); exiting"; exit 0 ;;
+        *)  die "could not acquire lock $lockfile (flock exited $rc)" ;;
+    esac
 }

--- a/ops/install.sh
+++ b/ops/install.sh
@@ -18,13 +18,27 @@ BACKUP_DIR="${BACKUP_DIR:-/mnt/docker-data/backups/postgres}"
 BEGIN_MARK="# >>> backend ops (managed by ops/install.sh) >>>"
 END_MARK="# <<< backend ops <<<"
 
-main() {
-    [[ "${1:-}" == "--uninstall" ]] && { uninstall; exit 0; }
+# The one cron line the old setup used, matched in full so that a hand-written
+# variant of it is never silently thrown away. Override if yours differs.
+LEGACY_CRON="${LEGACY_CRON:-15 9 * * * $HOME/scripts/backend_healthcheck.sh >> $HOME/logs/backend_healthcheck.log 2>&1}"
 
+die() { echo "install.sh: $*" >&2; exit 1; }
+
+main() {
+    # A typo like --uninstal must not silently fall through to a full install,
+    # which would rewrite the managed cron block.
+    case "${1:-}" in
+        "")          ;;
+        --uninstall) uninstall; exit 0 ;;
+        *)           die "unknown argument: $1 (usage: $0 [--uninstall])" ;;
+    esac
+
+    # Before anything is written, not after: a syntax error found post-install
+    # leaves broken scripts on disk and broken jobs in cron.
+    verify
     install_scripts
     install_dirs
     install_cron
-    verify
 
     cat <<EOF
 
@@ -53,22 +67,48 @@ install_dirs() {
     mkdir -p "$LOG_DIR"
 
     # The backup directory lives on the large second disk, not the root volume.
+    # Only the directory itself changes hands: a recursive chown of its parent
+    # would take ownership of every unrelated backup set stored alongside it.
     if [[ ! -d "$BACKUP_DIR" ]]; then
         sudo mkdir -p "$BACKUP_DIR"
-        sudo chown -R "$(id -u):$(id -g)" "$(dirname "$BACKUP_DIR")"
+        sudo chown "$(id -u):$(id -g)" "$BACKUP_DIR"
+        sudo chmod 0700 "$BACKUP_DIR"
     fi
     echo "backup dir: $BACKUP_DIR"
 }
 
+# `crontab -l 2>/dev/null || true` turns *any* read failure into an empty crontab,
+# and the crontab written from it would then wipe every hand-written job on the
+# box. Only "this user has no crontab yet" may be treated as empty.
+read_crontab() {
+    local out rc=0
+    out="$(crontab -l 2>&1)" || rc=$?
+
+    if (( rc == 0 )); then
+        printf '%s\n' "$out"
+        return 0
+    fi
+    [[ "$out" == *"no crontab for"* ]] && return 0
+
+    die "cannot read the current crontab (exit $rc): $out"
+}
+
 install_cron() {
     local current new
-    current="$(crontab -l 2>/dev/null || true)"
+    current="$(read_crontab)"
 
-    # Drop any previous managed block, and retire the old daily container-only
-    # healthcheck -- server-watchdog.sh covers it and much more, hourly.
+    # Drop any previous managed block.
     new="$(printf '%s\n' "$current" \
-        | sed "/$(escape "$BEGIN_MARK")/,/$(escape "$END_MARK")/d" \
-        | grep -v 'backend_healthcheck.sh' || true)"
+        | sed "/$(escape "$BEGIN_MARK")/,/$(escape "$END_MARK")/d")"
+
+    # Retire the old daily container-only healthcheck -- server-watchdog.sh covers
+    # it and much more, hourly. Matched as a whole line against the exact legacy
+    # entry: a substring match on the script name would also delete a hand-written
+    # invocation of it, which this script promises never to touch.
+    if printf '%s\n' "$new" | grep -qxF -- "$LEGACY_CRON"; then
+        new="$(printf '%s\n' "$new" | grep -vxF -- "$LEGACY_CRON" || true)"
+        echo "retired the legacy healthcheck entry (superseded by server-watchdog.sh)"
+    fi
 
     new+="
 $BEGIN_MARK
@@ -86,7 +126,7 @@ $END_MARK"
 
 uninstall() {
     local current
-    current="$(crontab -l 2>/dev/null || true)"
+    current="$(read_crontab)"
     printf '%s\n' "$current" \
         | sed "/$(escape "$BEGIN_MARK")/,/$(escape "$END_MARK")/d" \
         | crontab -
@@ -95,10 +135,12 @@ uninstall() {
 
 verify() {
     local script ok=1
-    for script in pg-backup.sh pg-restore-test.sh server-watchdog.sh caddy-reload.sh; do
-        bash -n "$DEST_DIR/$script" || { echo "SYNTAX ERROR in $script" >&2; ok=0; }
+    # common.sh included: every other script sources it, so a syntax error there
+    # breaks all four at once. Checked in $SRC_DIR because this runs before install.
+    for script in common.sh pg-backup.sh pg-restore-test.sh server-watchdog.sh caddy-reload.sh; do
+        bash -n "$SRC_DIR/$script" || { echo "SYNTAX ERROR in $script" >&2; ok=0; }
     done
-    (( ok )) || exit 1
+    (( ok )) || die "refusing to install scripts that do not parse"
     echo "syntax check passed"
 }
 

--- a/ops/server-watchdog.sh
+++ b/ops/server-watchdog.sh
@@ -19,7 +19,9 @@ set -euo pipefail
 
 . "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/common.sh"
 
-DISK_WARN_PCT="${DISK_WARN_PCT:-85}"
+# 80, not 85: the incident this script was written for was a root disk at 80%,
+# and a default that would have slept through it is not a default.
+DISK_WARN_PCT="${DISK_WARN_PCT:-80}"
 MEM_MIN_MB="${MEM_MIN_MB:-250}"
 PID1_MAX_MB="${PID1_MAX_MB:-200}"
 UNITS_MAX="${UNITS_MAX:-1000}"
@@ -102,7 +104,9 @@ check_disk() {
     local mount pct
     for mount in / /mnt/docker-data; do
         [[ -d "$mount" ]] || continue
-        pct="$(df -P "$mount" 2>/dev/null | awk 'NR==2 {gsub(/%/,"",$5); print $5}')"
+        # `set -o pipefail` makes a failing df abort the assignment, and `set -e`
+        # would then kill the whole watchdog run rather than skip one mount.
+        pct="$(df -P "$mount" 2>/dev/null | awk 'NR==2 {gsub(/%/,"",$5); print $5}')" || pct=""
         [[ -n "$pct" ]] || continue
         (( pct >= DISK_WARN_PCT )) && problem "Disk $mount er ${pct}% full (grense ${DISK_WARN_PCT}%)"
     done
@@ -130,10 +134,19 @@ check_memory() {
 # The 2026-07-25 leak in one check: PID 1 grew to 890 MB because failed transient
 # units are retained in memory forever. Both numbers are flat on a healthy box.
 check_systemd() {
-    local pid1_mb units failed
-    pid1_mb=$(( $(awk '{print $1}' <<< "$(ps -o rss= -p 1)") / 1024 ))
-    units="$(systemctl list-units --all --plain --no-pager 2>/dev/null | wc -l)"
-    failed="$(systemctl --failed --plain --no-pager 2>/dev/null | grep -c '\.service' || true)"
+    local pid1_kb pid1_mb units failed
+    # Under memory pressure -- the very condition being measured -- systemctl is
+    # what fails first. Letting that abort the run would silence the watchdog at
+    # exactly the moment it matters, so an unreadable value becomes a finding.
+    pid1_kb="$(ps -o rss= -p 1 2>/dev/null | awk '{print $1}')" || pid1_kb=""
+    units="$(systemctl list-units --all --plain --no-pager 2>/dev/null | wc -l)" || units=""
+    failed="$(systemctl --failed --plain --no-pager 2>/dev/null | grep -c '\.service')" || failed=0
+
+    if [[ -z "$pid1_kb" || -z "$units" ]]; then
+        problem "Fikk ikke lest systemd-tall (ps/systemctl svarte ikke) -- selve verktøyet kan være rammet"
+        return 0
+    fi
+    pid1_mb=$(( pid1_kb / 1024 ))
 
     (( pid1_mb > PID1_MAX_MB )) && problem "systemd (PID 1) bruker ${pid1_mb} MB (normalt ~15 MB) -- kjør 'systemctl reset-failed' så 'daemon-reexec'"
     (( units > UNITS_MAX )) && problem "${units} systemd-units lastet (grense ${UNITS_MAX}) -- gravsteiner hoper seg opp"
@@ -155,8 +168,11 @@ check_caddy() {
 check_certs() {
     local host expiry_date expiry_epoch days
     for host in $CERT_HOSTS; do
+        # An unreachable host makes this pipeline fail, and with `pipefail` the
+        # assignment fails with it -- killing the entire watchdog before it could
+        # report the unreachable host. Empty means "could not probe", handled below.
         expiry_date="$(echo | timeout 15 openssl s_client -connect "$host:443" -servername "$host" 2>/dev/null \
-            | openssl x509 -noout -enddate 2>/dev/null | cut -d= -f2)"
+            | openssl x509 -noout -enddate 2>/dev/null | cut -d= -f2)" || expiry_date=""
 
         if [[ -z "$expiry_date" ]]; then
             problem "Fikk ikke hentet sertifikat for $host"
@@ -199,10 +215,15 @@ report() {
 
     if (( count == 0 )); then
         log "alle sjekker OK"
-        # Only announce recovery if there was something to recover from.
+        # Only announce recovery if there was something to recover from -- and
+        # only clear the state once the announcement actually went out, so a
+        # failed delivery is retried instead of being forgotten.
         if [[ -s "$STATE_FILE" ]]; then
-            notify ":white_check_mark: **Alt friskt igjen** på $(hostname)"
-            rm -f "$STATE_FILE"
+            if (( DRY_RUN )); then
+                log "(dry-run: ville meldt at alt er friskt igjen)"
+            elif notify ":white_check_mark: **Alt friskt igjen** på $(hostname)"; then
+                rm -f "$STATE_FILE"
+            fi
         fi
         return 0
     fi
@@ -234,15 +255,20 @@ report() {
         return 0
     fi
 
-    notify ":warning: **${count} problem(er)** på $(hostname)
+    # Record the alert as sent only if it was. Otherwise an undelivered warning
+    # would start the REMIND_HOURS clock and suppress every retry for half a day.
+    if notify ":warning: **${count} problem(er)** på $(hostname)
 
-$body"
-
-    printf '%s\n%s\n' "$fingerprint" "$(date +%s)" > "$STATE_FILE"
+$body"; then
+        printf '%s\n%s\n' "$fingerprint" "$(date +%s)" > "$STATE_FILE"
+    fi
 }
 
 notify() {
-    send_notification "$1" || log "ADVARSEL: kunne ikke levere varselet" >&2
+    if ! send_notification "$1"; then
+        log "ADVARSEL: kunne ikke levere varselet" >&2
+        return 1
+    fi
 }
 
 main "$@"


### PR DESCRIPTION
Follow-up to #97. CodeRabbit reported 16 findings across the four ops scripts; all
are addressed here. Three classes, plus one leak.

## Fail-open under `set -e` + `pipefail`

A failing command substitution aborts the script *before* its own error handling
runs. The watchdog therefore died silently whenever a certificate host was
unreachable — reporting nothing at the moment an alert was most warranted.
Demonstrated against the version currently installed on the server:

```
$ CERT_HOSTS="no-such-host.invalid" ~/ops/server-watchdog.sh --dry-run
  exit=1        # no output at all

$ CERT_HOSTS="no-such-host.invalid" /tmp/ops-test/server-watchdog.sh --dry-run
2026-07-25T09:27:36Z 1 problem(er):
- Fikk ikke hentet sertifikat for no-such-host.invalid
  exit=0
```

Same shape fixed in `check_disk`, `check_systemd` and the Caddy admin-API reload.
`systemctl` failing under memory pressure is now reported as a finding rather than
being fatal — that is the exact incident this watchdog exists to catch.

## Silent skips

- `flock -n 9 || exit 0` could not distinguish lock contention from `flock` itself
  failing, so any operational error looked like a healthy skip. Contention now has
  its own exit code; anything else is fatal.
- `notify()` returned `log()`'s status, so an **undelivered** alert was recorded as
  sent and suppressed retries for `REMIND_HOURS`.
- `die()` only wrote to a log file nobody reads. It now notifies.
- `--dry-run` could send a real recovery message and clear the state file.

## Destructive installs

- `chown -R` on the backup directory's **parent** took ownership of every unrelated
  backup set under `/mnt/docker-data/backups`.
- `crontab -l 2>/dev/null || true` turned any read failure into an empty crontab,
  which the following `crontab -` would then make real — wiping hand-written jobs.
- The legacy healthcheck entry was matched by substring, so it deleted a
  hand-written line the script's own header promises to preserve. Now matched in
  full, as a whole line.
- `verify()` ran *after* installing, and skipped `common.sh` — which every other
  script sources.
- A typo like `--uninstal` fell through to a full install.

## Secret exposure

The webhook URL was passed as a `curl` argument, exposing it through `ps` and
`/proc` to every user on the box — in a file whose own header states the URL must
never end up in `ps` output. It now goes in through a curl config on stdin.

## Threshold

`DISK_WARN_PCT` 85 → 80. The incident this script was written for was a root disk
at 80%; a default that sleeps through it is not a default.

## Verification

- `bash -n` clean on all six scripts; `shellcheck -x` clean (exit 0, no output).
- Behaviour tested on the server: typo rejected without touching cron; lock
  contention exits 0 while a broken `flock` is fatal; the unreachable-host
  regression above.
- The widened Caddy config comparison was checked against the live production
  config: no false mismatch, and it catches a `logging` change that the previous
  `apps`-only check passed as a success.