### PR TITLE
sec: gate agent skills with SkillSpector

### DIFF
--- a/.github/workflows/skillspector.yml
+++ b/.github/workflows/skillspector.yml
@@ -1,0 +1,60 @@
+name: Skill security
+
+# Gates agent skills (SKILL.md) committed to this repo. There are none today --
+# the job is a no-op that passes. It exists so the first one to land is scanned
+# before it merges, rather than after someone notices.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: skillscan-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    name: SkillSpector
+    runs-on: ubuntu-latest
+    env:
+      # Pinned to a commit, not a branch. SkillSpector publishes no tags, so an
+      # unpinned git+https install would let an upstream push silently change
+      # what gates this repo -- the supply-chain risk the scanner itself looks
+      # for. Bump this deliberately, in a PR.
+      SKILLSPECTOR_REF: fd25398d7aa99353d86237b9c260759351f0e644
+      # Accepted findings live in the repo, reviewed like any other change.
+      SKILL_SCAN_BASELINE_DIR: ${{ github.workspace }}/.skillspector/baselines
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+
+      - name: Install SkillSpector
+        run: |
+          uv tool install "skillspector @ git+https://github.com/NVIDIA/skillspector.git@${SKILLSPECTOR_REF}"
+          # uv tool installs into ~/.local/bin, which is not on the runner PATH.
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Scan skills committed to this repo
+        run: |
+          echo '### SkillSpector' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          # rc captured explicitly: the runner shell is `bash -eo pipefail`, so
+          # without this the step dies at the pipe and the summary is never
+          # closed -- and a scan that never ran must not look like a clean one.
+          rc=0
+          tools/skill-scan.sh --repo | tee -a "$GITHUB_STEP_SUMMARY" || rc=$?
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          case "$rc" in
+            0) ;;
+            1) echo "::error::a skill in this repo scored at or above HIGH" ;;
+            *) echo "::error::the scan could not complete (exit $rc)" ;;
+          esac
+          exit "$rc"

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "skillspector": {
+      "command": "skillspector",
+      "args": ["mcp"]
+    }
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,20 @@
 # Local development helpers. Run `make help` for the list.
 DEV := docker compose -f docker-compose.dev.yml
 
-.PHONY: help dev-up dev-up-build dev-down dev-logs dev-ps dev-restart dev-psql headers migrate migration migrate-down db-stamp hooks
+.PHONY: help dev-up dev-up-build dev-down dev-logs dev-ps dev-restart dev-psql headers migrate migration migrate-down db-stamp hooks skill-scan skill-audit
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN{FS=":.*?## "}{printf "  \033[36m%-16s\033[0m %s\n", $$1, $$2}'
 
 hooks: ## Install the git pre-commit hooks (ruff + mypy, mirrors CI)
 	uv run pre-commit install
+
+skill-scan: ## Vet an agent skill before installing it: make skill-scan target=<path|url>
+	@test -n "$(target)" || { echo 'usage: make skill-scan target=<path|url>'; exit 2; }
+	tools/skill-scan.sh "$(target)"
+
+skill-audit: ## Scan every agent skill installed under ~/.claude
+	tools/skill-scan.sh --installed
 
 dev-up: ## Start the local stack (db + all apps, hot-reload) and apply migrations
 	$(DEV) up -d

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,98 @@
+# Agent skill scanning
+
+[SkillSpector](https://github.com/NVIDIA/skillspector) (NVIDIA, Apache-2.0) scans
+agent skills for prompt injection, data exfiltration, privilege escalation and
+supply-chain risk. Agent skills execute with your privileges and are installed
+with roughly the vetting of a curl-pipe-bash, which is the gap this closes.
+
+`skill-scan.sh` is the only entry point. Three uses, one script, so the
+threshold and the exit-code rules cannot drift apart between them.
+
+## Install
+
+```bash
+uv tool install 'skillspector[mcp] @ git+https://github.com/NVIDIA/skillspector.git@fd25398d7aa99353d86237b9c260759351f0e644'
+```
+
+Pinned to a commit because upstream publishes no tags. The same SHA is pinned in
+`.github/workflows/skillspector.yml` — bump both together.
+
+## Use
+
+```bash
+make skill-scan target=https://github.com/someone/their-skill   # before installing
+make skill-audit                                                # everything under ~/.claude
+tools/skill-scan.sh --repo                                      # what CI runs
+```
+
+Exit codes are the contract:
+
+| Code | Meaning |
+| --- | --- |
+| `0` | nothing at or above the threshold |
+| `1` | a skill tripped the gate |
+| `2` | the scan could not complete — **not** a pass |
+
+Code `2` is separate on purpose. A gate that reports its own failure as success
+is worse than no gate, so a missing or unparseable report is a hard error. Call
+the script directly rather than through `make` when you need that distinction —
+`make` reports both as its own exit 2.
+
+Knobs: `SKILL_SCAN_FAIL_ON` (default `HIGH`), `SKILL_SCAN_BASELINE_DIR`,
+`CLAUDE_DIR`, `SKILL_SCAN_LLM=1` to add the LLM pass (costs API credits; static
+analysis is the default).
+
+## Baselines
+
+Static pattern matching is noisy on legitimate skills. Accept what you have
+triaged so re-scans only surface what is *new*:
+
+```bash
+tools/skill-scan.sh --accept --installed
+```
+
+One file per skill under `$SKILL_SCAN_BASELINE_DIR` (default
+`~/.claude/skillspector-baselines`), not one merged file: fingerprints are
+content hashes scoped to a path relative to the skill root, so merging lets an
+accepted finding in one skill suppress an identical-looking one in another.
+
+**Read the findings before accepting them.** `--accept` is how a real
+vulnerability gets permanently silenced.
+
+## How noisy, concretely
+
+First run against the 67 skills installed on this machine, all from Anthropic's
+official marketplaces: **407 findings — 1 CRITICAL, 99 HIGH.** Triaging a sample
+of them:
+
+| Reported | Actually |
+| --- | --- |
+| CRITICAL: `pillow==10.0.0`, 10 CVEs incl. RCE | `requirements.txt` says `pillow>=10.0.0` — a floor, read as a pin |
+| Env variable harvesting | `os.environ["GITHUB_TOKEN"]` in a documentation example |
+| Env variable harvesting | `os.environ.copy()`, the standard subprocess idiom |
+| Hidden instructions in a `.xsd` | a byte-order mark (U+FEFF) |
+| Prompt injection in `receipts` | the paragraph *defending against* prompt injection |
+| `subprocess.Popen(shell=True)` | real, and worth knowing |
+| `&& sudo`, `--noconfirm` | real, in a skill whose job is installing things |
+
+Zero confirmed vulnerabilities in what was installed. So the value is not the
+audit — it is the gate on what gets installed next, and the baseline that makes
+a new finding stand out instead of drowning in 407 old ones.
+
+## CI
+
+`.github/workflows/skillspector.yml` runs `--repo` on every PR. The repo has no
+`SKILL.md` today, so it passes trivially; it exists so the first one to land is
+scanned before it merges. Baselines for repo skills go in `.skillspector/baselines/`
+and are reviewed like any other change.
+
+Note that on a `pull_request` event the workflow runs the PR's copy of this
+script. That is inherent to running any repo tooling on PR code, and the job has
+a read-only token and no secrets — but do not treat a green check on an untrusted
+PR as proof the skill in it is safe. Read the diff.
+
+## MCP
+
+`.mcp.json` registers SkillSpector as a project-scoped MCP server exposing a
+single `scan_skill` tool, so an agent session can vet a skill without shelling
+out. It needs the `[mcp]` extra from the install line above.

--- a/tools/skill-scan.sh
+++ b/tools/skill-scan.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+#
+# SkillSpector wrapper -- the single entry point for scanning agent skills.
+#
+# Used in three places, all calling this one script so the threshold, the
+# baseline and the exit-code rules can never drift apart:
+#
+#   1. Before installing anything:  tools/skill-scan.sh https://github.com/x/y
+#   2. Auditing this machine:       tools/skill-scan.sh --installed
+#   3. CI (.github/workflows):      tools/skill-scan.sh --repo
+#
+# Findings you have looked at and accepted go into a baseline, one file per
+# skill, so a re-scan only surfaces what is *new*. Per skill rather than one
+# merged file because the fingerprints are content hashes scoped to a relative
+# path: merging them lets an accepted finding in one skill silently suppress an
+# identical-looking one in another.
+#
+# `skillspector scan` already exits non-zero on a risky skill, but it only walks
+# *immediate* subdirectories and it cannot tell "this skill is dangerous" apart
+# from "the scanner crashed". Both matter here: a security gate that treats its
+# own failure as a pass is worse than no gate, so every scan must produce a
+# parseable report or this script fails closed.
+#
+# Env:
+#   SKILL_SCAN_FAIL_ON      LOW|MEDIUM|HIGH|CRITICAL  severity that fails the run (default HIGH)
+#   SKILL_SCAN_BASELINE_DIR directory of baselines    default $CLAUDE_DIR/skillspector-baselines
+#   CLAUDE_DIR              agent config dir          default ~/.claude
+#   SKILL_SCAN_LLM          1 to enable LLM analysis  default off (no API cost)
+
+set -euo pipefail
+
+FAIL_ON="${SKILL_SCAN_FAIL_ON:-HIGH}"
+CLAUDE_DIR="${CLAUDE_DIR:-$HOME/.claude}"
+BASELINE_DIR="${SKILL_SCAN_BASELINE_DIR:-$CLAUDE_DIR/skillspector-baselines}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ACCEPT=0
+
+die() { echo "skill-scan: $*" >&2; exit 2; }
+
+# Reports are written to a scratch dir. The cleanup handler is installed at the
+# top level -- registering it inside a function would leave it referencing a
+# `local` that is out of scope by the time the trap actually fires -- and it
+# hands back the status it was called with, because a successful `rm` must never
+# overwrite a failing exit code and turn a tripped gate into a pass.
+WORKDIR=""
+cleanup() {
+    local rc=$?
+    [[ -n "$WORKDIR" ]] && rm -rf "$WORKDIR"
+    exit "$rc"
+}
+trap cleanup EXIT
+
+# Severity ranking. Exit codes: 0 clean, 1 gate tripped, 2 could not scan --
+# distinct on purpose so CI can tell a real finding from a broken toolchain.
+# `tr`, not ${x^^}: macOS ships bash 3.2 and this script has to run identically
+# on the laptop that vets a skill and on the ubuntu runner that gates the repo.
+severity_rank() {
+    case "$(printf '%s' "$1" | tr '[:lower:]' '[:upper:]')" in
+        LOW)      echo 1 ;;
+        MEDIUM)   echo 2 ;;
+        HIGH)     echo 3 ;;
+        CRITICAL) echo 4 ;;
+        *)        echo 0 ;;
+    esac
+}
+
+usage() {
+    cat >&2 <<EOF
+usage: $0 [--accept] <path|url>...
+       $0 [--accept] --installed    every skill under $CLAUDE_DIR
+       $0 [--accept] --repo         every skill committed to this repo
+
+  --accept  record the current findings as a baseline instead of scanning,
+            so later runs report only NEW findings. Read them first.
+EOF
+    exit 2
+}
+
+main() {
+    (( $# )) || usage
+
+    if [[ "$1" == "--accept" ]]; then
+        ACCEPT=1
+        shift
+        (( $# )) || usage
+    fi
+
+    command -v skillspector >/dev/null 2>&1 \
+        || die "skillspector not installed -- uv tool install git+https://github.com/NVIDIA/skillspector.git"
+    command -v python3 >/dev/null 2>&1 || die "python3 not found"
+
+    local threshold
+    threshold="$(severity_rank "$FAIL_ON")"
+    (( threshold )) || die "SKILL_SCAN_FAIL_ON must be LOW, MEDIUM, HIGH or CRITICAL (got: $FAIL_ON)"
+
+    # Collected with read -r rather than mapfile for the same bash 3.2 reason,
+    # and through process substitution so the array survives the loop.
+    local -a targets=()
+    local root="" dir
+    case "$1" in
+        --installed) root="$CLAUDE_DIR" ;;
+        --repo)      root="$REPO_ROOT" ;;
+        -h|--help)   usage ;;
+        -*)          die "unknown option: $1" ;;
+        *)           targets=("$@") ;;
+    esac
+
+    if [[ -n "$root" ]]; then
+        # Checked here, not inside find_skills: that runs in a process
+        # substitution, so a die() in there would kill only the subshell and the
+        # parent would read an empty list and call a mistyped root a clean pass.
+        [[ -d "$root" ]] || die "not a directory: $root"
+        while IFS= read -r dir; do
+            [[ -n "$dir" ]] && targets+=("$dir")
+        done < <(find_skills "$root")
+    fi
+
+    if (( ${#targets[@]} == 0 )); then
+        # Only reachable via --installed/--repo. Nothing to scan is a pass, but
+        # say so out loud: a silently empty gate looks identical to a passing one.
+        echo "no SKILL.md found under the requested root -- nothing to scan"
+        return 0
+    fi
+
+    if (( ACCEPT )); then
+        accept_all "${targets[@]}"
+        return 0
+    fi
+    scan_all "$threshold" "${targets[@]}"
+}
+
+# One baseline per skill, named after its path so the mapping is obvious when
+# you later wonder why a finding stopped being reported.
+baseline_path() {
+    local slug
+    # Leading dots are stripped: most skills live under ~/.claude, and keeping
+    # that dot would make every baseline a hidden file -- invisible to `ls`, and
+    # easy to lose track of for something whose whole job is suppressing alerts.
+    slug="$(printf '%s' "${1#"$HOME"/}" | sed 's|[^A-Za-z0-9._-]|_|g; s|^[._]*||')"
+    printf '%s/%s.yaml' "$BASELINE_DIR" "$slug"
+}
+
+accept_all() {
+    local target out
+    mkdir -p "$BASELINE_DIR" || die "cannot create baseline directory: $BASELINE_DIR"
+
+    for target in "$@"; do
+        out="$(baseline_path "$target")"
+        skillspector baseline "$target" --no-llm --output "$out" >/dev/null 2>&1 || true
+        # No baseline file means the accept did not happen. Saying "accepted"
+        # anyway would leave you believing findings are triaged when a later
+        # scan will still report every one of them.
+        [[ -s "$out" ]] || die "could not write a baseline for $target"
+        echo "accepted: $(display_name "$target")  ->  $(tildify "$out")"
+    done
+    echo
+    echo "$# baseline(s) written. Future scans report only NEW findings."
+}
+
+# Skills nest at arbitrary depth (marketplace/plugins/<p>/skills/<s>/SKILL.md),
+# which is why `skillspector -r` alone is not enough.
+find_skills() {
+    local root="$1"
+    [[ -d "$root" ]] || die "not a directory: $root"
+    # find's stderr is deliberately not silenced. A directory it cannot read
+    # would otherwise shrink the target list without a word, and a gate that
+    # skips a skill looks exactly like a gate that cleared it.
+    find "$root" \
+        \( -name .venv -o -name node_modules -o -name .git -o -name worktrees \) -prune -o \
+        -name SKILL.md -print \
+        | while IFS= read -r f; do dirname "$f"; done \
+        | sort -u
+}
+
+scan_all() {
+    local threshold="$1"; shift
+    local flagged=0 scanned=0
+    WORKDIR="$(mktemp -d)" || die "cannot create temp directory"
+
+    local -a llm_arg=(--no-llm)
+    [[ "${SKILL_SCAN_LLM:-0}" == "1" ]] && llm_arg=()
+
+    printf '%-8s %-9s %5s  %s\n' "SCORE" "SEVERITY" "FIND" "SKILL"
+    printf -- '---------------------------------------------------------------------\n'
+
+    local target report line score severity count rank baseline
+    local -a baseline_arg=()
+    for target in "$@"; do
+        scanned=$((scanned + 1))
+        report="$WORKDIR/$scanned.json"
+
+        # A baseline is used when one exists for this exact skill; a missing one
+        # simply means nothing has been accepted yet, which must scan everything
+        # rather than quietly skip the skill.
+        baseline_arg=()
+        baseline="$(baseline_path "$target")"
+        [[ -s "$baseline" ]] && baseline_arg=(--baseline "$baseline")
+
+        # The exit code is deliberately ignored here: non-zero means either "risky
+        # skill" or "scanner broke", and only the report can tell those apart.
+        # ${a[@]+"${a[@]}"}: on bash 3.2 an empty array under `set -u` is an
+        # unbound-variable error, which would abort the scan mid-gate.
+        skillspector scan "$target" \
+            ${llm_arg[@]+"${llm_arg[@]}"} ${baseline_arg[@]+"${baseline_arg[@]}"} \
+            --format json --output "$report" >/dev/null 2>&1 || true
+
+        [[ -s "$report" ]] || die "no report produced for $target -- scan did not complete"
+
+        line="$(read_report "$report" "$target")" \
+            || die "unreadable report for $target -- refusing to call this a pass"
+
+        IFS='|' read -r score severity count <<<"$line"
+        printf '%-8s %-9s %5s  %s\n' "$score" "$severity" "$count" "$(display_name "$target")"
+
+        rank="$(severity_rank "$severity")"
+        # `count` matters as well as `rank`: a skill with nothing wrong still
+        # carries the severity label LOW, so gating on the label alone would make
+        # SKILL_SCAN_FAIL_ON=LOW fail every clean skill and be useless.
+        if (( count > 0 && rank >= threshold )); then
+            flagged=$((flagged + 1))
+            details "$report"
+        fi
+    done
+
+    echo
+    if (( flagged )); then
+        echo "FAIL: $flagged of $scanned skill(s) at or above $FAIL_ON"
+        return 1
+    fi
+    echo "PASS: $scanned skill(s) scanned, none at or above $FAIL_ON"
+}
+
+# Parsing lives in python because a truncated or malformed report must raise,
+# not silently yield an empty score that would round down to "clean".
+read_report() {
+    REPORT="$1" python3 -c '
+import json, os, sys
+with open(os.environ["REPORT"]) as fh:
+    d = json.load(fh)
+ra = d["risk_assessment"]
+print("%s|%s|%d" % (ra["score"], ra["severity"], len(d.get("issues", []))))
+' 2>/dev/null
+}
+
+details() {
+    REPORT="$1" THRESHOLD="$FAIL_ON" python3 -c '
+import json, os
+rank = {"LOW": 1, "MEDIUM": 2, "HIGH": 3, "CRITICAL": 4}
+floor = rank[os.environ["THRESHOLD"].upper()]
+with open(os.environ["REPORT"]) as fh:
+    d = json.load(fh)
+for i in d.get("issues", []):
+    if rank.get(i.get("severity", "").upper(), 0) < floor:
+        continue
+    loc = i.get("location") or {}
+    where = loc.get("file", "?") if isinstance(loc, dict) else str(loc)
+    line = loc.get("start_line") if isinstance(loc, dict) else None
+    print("    [%s] %s / %s" % (i["severity"].upper(), i.get("category"), i.get("pattern")))
+    print("      %s%s -- %s" % (where, ":%s" % line if line else "", str(i.get("finding", ""))[:100]))
+'
+}
+
+tildify() {
+    case "$1" in
+        "$HOME"/*) printf '~%s' "${1#"$HOME"}" ;;
+        *)         printf '%s' "$1" ;;
+    esac
+}
+
+# Full marketplace paths are unreadable in a table; the skill and its plugin are
+# what identify it.
+display_name() {
+    [[ "$1" == *://* ]] && { echo "$1"; return; }
+    echo "$1" | rev | cut -d/ -f1-2 | rev
+}
+
+main "$@"


### PR DESCRIPTION
Sets up [SkillSpector](https://github.com/NVIDIA/skillspector) (NVIDIA, Apache-2.0) — a security scanner for agent skills — three ways, all through one script.

Agent skills execute with your privileges and are installed with roughly the vetting of a curl-pipe-bash. This closes that gap.

## What landed

| File | Why |
| --- | --- |
| `tools/skill-scan.sh` | the only entry point: vet-before-install, audit `~/.claude`, gate the repo in CI |
| `.github/workflows/skillspector.yml` | runs `--repo` on every PR |
| `.mcp.json` | project-scoped MCP server, so an agent session can vet a skill without shelling out |
| `Makefile` | `make skill-scan target=…`, `make skill-audit` |
| `tools/README.md` | usage, and the triage that explains the noise level |

## Exit codes are the contract

`0` clean · `1` gate tripped · `2` **could not scan**

The third is separate on purpose. A gate that reports its own failure as success is worse than no gate, so a missing or unparseable report is a hard error. Verified with a stub scanner that exits non-zero writing nothing (→ 2) and one that writes truncated JSON (→ 2).

## Scanner is pinned to a commit

Upstream publishes no tags. An unpinned `git+https://` install would let an upstream push silently change what gates this repo — the supply-chain risk the scanner itself looks for. The same SHA is in the workflow and the README.

## What the first scan actually found

407 findings across the 67 installed skills — 1 CRITICAL, 99 HIGH — and **zero confirmed vulnerabilities** on triage:

| Reported | Actually |
| --- | --- |
| CRITICAL: `pillow==10.0.0`, 10 CVEs incl. RCE | `requirements.txt` says `pillow>=10.0.0` — a floor, read as a pin |
| Env variable harvesting | `os.environ["GITHUB_TOKEN"]` in a doc example |
| Hidden instructions in a `.xsd` | a byte-order mark (U+FEFF) |
| Prompt injection in `receipts` | the paragraph *defending against* prompt injection |
| `subprocess.Popen(shell=True)` | real, and worth knowing |

So the value is the gate on what gets installed next, not the audit. Those findings are accepted into per-skill baselines (one file per skill — merging lets an accepted finding in one skill suppress a look-alike in another) so a new finding stands out.

## Proof the baseline does not blind it

Copied a skill, accepted it (`PASS`), then appended `curl … | bash` and a read of `~/.aws/credentials` to its `SKILL.md`. Re-scan with the baseline still in place:

```
62  HIGH  3  canary/victim
    [HIGH] Supply Chain / External Script Fetching   SKILL.md:98
    [HIGH] Privilege Escalation / Credential Access  SKILL.md:99
    [HIGH] Tool Misuse / Chaining Abuse              SKILL.md:98
FAIL: 1 of 1 skill(s) at or above HIGH   (exit 1)
```

## Testing

`shellcheck` clean. Exit-code matrix, all as intended:

```
repo (empty)            0     LOW vs 0-finding skill    0
installed w/ baselines  0     LOW vs 1-finding skill    1
clean skill             0     CRITICAL vs claude-api    1
missing dir             2     CRITICAL vs HIGH skill    0
bad option              2     default HIGH vs HIGH      1
broken scanner          2     no baselines             1
```

Four fail-open bugs were found and fixed in this script while testing it, all the same class as the recent ops work: an EXIT trap whose `rm` overwrote the exit code, a `die` inside a process substitution that killed only the subshell (so a mistyped directory read as a clean pass), `find` silencing errors, and `FAIL_ON=LOW` failing every clean skill because `LOW` is also the floor label.

Note the repo has no `SKILL.md` today — CI passes trivially. It exists so the first one to land is scanned before it merges.