### PR TITLE
feat(site): live cursor presence over WebSocket

### DIFF
--- a/apps/shared/app_factory.py
+++ b/apps/shared/app_factory.py
@@ -13,6 +13,7 @@ from fastapi import APIRouter, FastAPI
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.openapi.docs import get_swagger_ui_oauth2_redirect_html
 from fastapi.staticfiles import StaticFiles
+from starlette.types import Lifespan
 
 from apps.shared.body_limit import BodySizeLimitMiddleware
 from apps.shared.cache_control_headers import setup_cache_control
@@ -30,6 +31,7 @@ def create_app(
     url_prefix: str,
     description: str = "",
     version: str = "1.0.0",
+    lifespan: Lifespan | None = None,
 ) -> FastAPI:
     """Build a hardened FastAPI app with locally-served docs under ``/<url_prefix>/docs``.
 
@@ -39,6 +41,11 @@ def create_app(
             drives ``openapi.json`` and the docs routes.
         description: Optional OpenAPI description.
         version: OpenAPI version string.
+        lifespan: Optional async context manager for startup/shutdown work.
+            Every app so far is stateless and needs none; the site service holds
+            open WebSockets and has to close them deliberately on SIGTERM, or
+            clients see a dropped connection instead of a close frame and answer
+            it with a reconnect storm.
 
     Returns:
         A configured ``FastAPI`` instance. Callers add their own routers.
@@ -50,6 +57,7 @@ def create_app(
         title=title,
         version=version,
         description=description,
+        lifespan=lifespan,
         # Built-in docs are disabled so Swagger UI is served from local /static
         # assets under a strict CSP instead of a third-party CDN.
         docs_url=None,

--- a/apps/shared/config.py
+++ b/apps/shared/config.py
@@ -107,6 +107,29 @@ class Settings(BaseSettings):
     visit_notify_throttle_seconds: int = 3600  # at most one ping per IP per hour
     visit_notify_exclude_ips: str = ""         # comma-separated IPs to ignore (e.g. yours)
 
+    # Live cursor presence (WebSocket). Every cap below is *per process*: the hub
+    # is in-memory, so two workers would each enforce its own limit and peers in
+    # the same room would never see each other. Single worker is a precondition,
+    # the same one the in-memory rate limiter already relies on.
+    cursor_max_connections: int = 200   # across every room in this process
+    cursor_max_per_room: int = 50
+    cursor_max_per_ip: int = 5          # one person's open tabs, not one person's site
+    cursor_max_rooms: int = 100
+    # Outbound batch rate. Clients may move the mouse at 60+ Hz; we collapse that
+    # to one frame per tick, so bandwidth scales with peers, not with mouse events.
+    cursor_tick_hz: float = 15.0
+    # Inbound cap per connection. Above it the socket is closed rather than
+    # throttled: a client past 60 msg/s is broken or hostile, not merely eager.
+    cursor_max_messages_per_second: float = 60.0
+    # Closed after this long without a single frame from the client. A backgrounded
+    # tab stops pinging and drops out, which is the correct presence semantic —
+    # protocol-level keepalive alone would hold its slot for hours.
+    cursor_idle_timeout_seconds: float = 900.0
+    # Frames buffered for a slow client before we give up on it. 64 at 15 Hz is
+    # ~4 s of backlog; anything further behind is a dead socket the OS hasn't
+    # noticed yet, and holding its queue only delays reclaiming the slot.
+    cursor_send_queue_size: int = 64
+
     # IP -> location lookup for the visit notification. `{ip}` is substituted with
     # a validated address. The default provider's free tier is HTTP-only; point
     # this at an HTTPS provider to stop leaking visitor IPs in the clear.
@@ -133,6 +156,26 @@ class Settings(BaseSettings):
         # whole feature depends on, so it's a startup error rather than a no-op.
         if v <= 0:
             raise ValueError("STRAVA_PRIVACY_RADIUS_M must be greater than 0")
+        return v
+
+    @field_validator(
+        "cursor_max_connections",
+        "cursor_max_per_room",
+        "cursor_max_per_ip",
+        "cursor_max_rooms",
+        "cursor_tick_hz",
+        "cursor_max_messages_per_second",
+        "cursor_idle_timeout_seconds",
+        "cursor_send_queue_size",
+    )
+    @classmethod
+    def _check_positive(cls, v: float, info) -> float:
+        # Zero is the dangerous value, not negative: CURSOR_TICK_HZ=0 divides by
+        # zero in the broadcast loop and CURSOR_MAX_CONNECTIONS=0 rejects every
+        # visitor — both are misconfigurations that should stop the process at
+        # startup rather than surface as a silently dead feature.
+        if v <= 0:
+            raise ValueError(f"{info.field_name.upper()} must be greater than 0")
         return v
 
     @property

--- a/apps/shared/config.py
+++ b/apps/shared/config.py
@@ -7,6 +7,7 @@ specific values it requires, so the fail-fast behaviour is preserved while the
 config lives in one typed place.
 """
 
+import math
 from functools import lru_cache
 from typing import Any
 
@@ -170,6 +171,12 @@ class Settings(BaseSettings):
     )
     @classmethod
     def _check_positive(cls, v: float, info) -> float:
+        # Checked first, because `v <= 0` cannot catch it: pydantic parses
+        # CURSOR_TICK_HZ=nan into a float, and every comparison against NaN is
+        # False — so it passes the guard below and then makes the broadcast loop
+        # sleep for NaN. "inf" and "1e999" get through the same way.
+        if not math.isfinite(v):
+            raise ValueError(f"{info.field_name.upper()} must be a finite number")
         # Zero is the dangerous value, not negative: CURSOR_TICK_HZ=0 divides by
         # zero in the broadcast loop and CURSOR_MAX_CONNECTIONS=0 rejects every
         # visitor — both are misconfigurations that should stop the process at

--- a/apps/shared/cors.py
+++ b/apps/shared/cors.py
@@ -47,6 +47,27 @@ def get_allowed_origins() -> list[str]:
     return origins
 
 
+def is_allowed_origin(origin: str | None) -> bool:
+    """Om en Origin-header skal slippe til på en WebSocket.
+
+    WebSocket-handshaken er *unntatt* same-origin policy: browseren sender
+    Origin, men håndhever ingenting selv, og `CORSMiddleware` slipper gjennom
+    alt som ikke har `scope["type"] == "http"`. Uten denne sjekken kan en
+    hvilken som helst nettside åpne en kanal mot oss på besøkendes vegne.
+
+    Origin-listen er den samme som for HTTP, med vilje: to lister som kan drifte
+    fra hverandre er akkurat den slags forskjell ingen oppdager før den utnyttes.
+
+    En request helt uten Origin er ikke en browser (curl, en helsesjekk, en
+    test). I produksjon avvises den — det finnes ingen legitim ikke-browser-
+    klient for denne kanalen — mens den slippes gjennom lokalt der wscat og
+    TestClient er hvordan man faktisk feilsøker.
+    """
+    if origin is None:
+        return not settings.is_production
+    return origin.rstrip("/") in get_allowed_origins()
+
+
 def setup_cors(app: FastAPI) -> None:
     """Legg til CORS-middleware på en FastAPI-app."""
     app.add_middleware(

--- a/apps/site/cursors.py
+++ b/apps/site/cursors.py
@@ -1,0 +1,597 @@
+"""Live cursor presence — a WebSocket room where everyone sees everyone's cursor.
+
+The frontend opens one socket per page, streams its pointer position, and gets
+back everyone else's. Colour is assigned here rather than in the browser: two
+clients picking their own would sometimes pick the same one, and there is no
+other place both of them can agree on. The frontend is free to ignore it.
+
+Three things shape this file, and none of them are optional:
+
+*Fan-out is batched.* A naive "broadcast every message" is O(n²): twenty peers
+moving the mouse at 60 Hz is 24 000 messages a second. Instead each peer's latest
+position is stored, and one loop per room emits a single combined frame at
+``CURSOR_TICK_HZ``. Outbound traffic then scales with the number of peers, not
+with how fast their mice move, and a client that spams is only spamming itself.
+
+*Every limit lives here.* The shared middleware stack — rate limiting, body caps
+— is registered with ``@app.middleware("http")`` and never sees a WebSocket
+scope. So the per-IP, per-room and global caps in this module are not defence in
+depth; for this endpoint they are the only defence there is.
+
+*State is per process.* The hub is a plain dict. Two uvicorn workers would each
+enforce their own caps and peers in the same room would never see one another —
+the same single-worker precondition ``apps.shared.rate_limit`` already documents.
+Sharding this across workers means a Redis pub/sub backend, not a bigger dict.
+
+Protocol, all JSON text frames.
+
+Client -> server::
+
+    {"t": "cursor", "x": 0.51, "y": 0.28}   # viewport fractions, clamped to [0,1]
+    {"t": "ping"}                           # answered with {"t":"pong"}
+
+Server -> client::
+
+    {"t":"welcome","id":..,"color":"#e11d48","room":"/","peers":[..],
+     "tick_hz":15.0,"idle_timeout_seconds":900.0}
+    {"t":"join","id":..,"color":..}
+    {"t":"leave","id":..}
+    {"t":"frame","c":{"<id>":[x,y], ...}}   # only peers that moved this tick
+    {"t":"pong"}
+    {"t":"error","code":"room_full"}        # sent just before a close
+
+Coordinates are fractions of the viewport rather than pixels so a 4K monitor and
+a phone agree on where the cursor is; converting back is ``x * width``.
+"""
+
+import asyncio
+import contextlib
+import json
+import logging
+import math
+import re
+import time
+import uuid
+from dataclasses import dataclass, field
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from starlette.websockets import WebSocketState
+
+from apps.shared.config import settings
+from apps.shared.cors import is_allowed_origin
+from apps.shared.net import client_ip
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/site")
+
+# Close codes. 1008 is "policy violation" (you are not allowed), 1013 is "try
+# again later" (you would be, but we are full) — the distinction is what lets the
+# frontend decide between giving up and backing off.
+CLOSE_POLICY = 1008
+CLOSE_TRY_LATER = 1013
+
+# Room names come from a query param, so they are attacker-controlled and are the
+# one string in this module that gets used as a dict key with a cap on cardinality.
+# Restricting the charset keeps them printable in logs and rules out the usual
+# lookalike tricks (newlines, control characters, unicode homoglyphs in paths).
+_ROOM_RE = re.compile(r"^[A-Za-z0-9/_.-]{1,64}$")
+DEFAULT_ROOM = "/"
+
+# Largest text frame we will even try to parse. A cursor update is ~40 bytes; the
+# `websockets` library's own limit is 1 MiB, which is four orders of magnitude
+# more slack than this protocol can justify.
+_MAX_FRAME_CHARS = 512
+
+# Consecutive unparseable frames tolerated before the socket is closed. One is a
+# glitch or a version skew; a stream of them is a client that will never work.
+_MAX_INVALID_FRAMES = 10
+
+# Distinct, roughly equal-luminance hues that stay legible on both a light and a
+# dark page. Assignment prefers whichever is unused in the room, so small rooms
+# never collide; past len(PALETTE) peers colours repeat, which is fine — at that
+# point the cursors are indistinguishable by position anyway.
+PALETTE = (
+    "#e11d48",  # rose
+    "#0ea5e9",  # sky
+    "#22c55e",  # green
+    "#f59e0b",  # amber
+    "#a855f7",  # purple
+    "#14b8a6",  # teal
+    "#ef4444",  # red
+    "#3b82f6",  # blue
+    "#84cc16",  # lime
+    "#ec4899",  # pink
+    "#f97316",  # orange
+    "#6366f1",  # indigo
+)
+
+
+class JoinRejected(Exception):
+    """A connection that passed the handshake but has no room to be let into."""
+
+    def __init__(self, reason: str, close_code: int) -> None:
+        super().__init__(reason)
+        self.reason = reason
+        self.close_code = close_code
+
+
+class _TokenBucket:
+    """Per-connection inbound allowance, refilled continuously.
+
+    Deliberately not the shared ``limits`` limiter: that one keys on IP across a
+    whole app and stores state in a backend, which is the wrong shape for
+    something checked on every frame of a socket that already owns its own state.
+    """
+
+    def __init__(self, rate: float, burst: float) -> None:
+        self._rate = rate
+        self._burst = burst
+        self._tokens = burst
+        self._checked = time.monotonic()
+
+    def take(self) -> bool:
+        now = time.monotonic()
+        self._tokens = min(self._burst, self._tokens + (now - self._checked) * self._rate)
+        self._checked = now
+        if self._tokens < 1.0:
+            return False
+        self._tokens -= 1.0
+        return True
+
+
+@dataclass
+class Peer:
+    """One connected browser tab."""
+
+    id: str
+    color: str
+    ip: str
+    ws: WebSocket
+    room: str
+    # Bounded on purpose: see CURSOR_SEND_QUEUE_SIZE. A full queue means the
+    # client stopped reading, and the only useful answer is to drop it.
+    queue: asyncio.Queue[str]
+    bucket: _TokenBucket
+    x: float = 0.5
+    y: float = 0.5
+    # Whether this peer has moved since the last tick. Frames carry only movers,
+    # so an idle room costs nothing to broadcast.
+    moved: bool = False
+    invalid_frames: int = 0
+    # Set once the peer has been given up on, so the broadcast loop stops
+    # queueing for it and only one close is ever scheduled.
+    stalled: bool = False
+
+
+@dataclass
+class Room:
+    name: str
+    peers: dict[str, Peer] = field(default_factory=dict)
+    task: asyncio.Task | None = None
+
+
+class CursorHub:
+    """Owns every room, every peer, and every cap.
+
+    All mutating methods are synchronous and never await, so they run to
+    completion between event-loop ticks. That is what makes "check the cap, then
+    take the slot" safe without a lock — inserting an await between the two would
+    let two connections both pass a check for the last remaining slot.
+    """
+
+    def __init__(self) -> None:
+        self._rooms: dict[str, Room] = {}
+        self._per_ip: dict[str, int] = {}
+        self._total = 0
+
+    # -- stats ------------------------------------------------------------
+
+    @property
+    def connections(self) -> int:
+        return self._total
+
+    @property
+    def room_count(self) -> int:
+        return len(self._rooms)
+
+    def peers_in(self, room: str) -> int:
+        found = self._rooms.get(room)
+        return len(found.peers) if found else 0
+
+    # -- membership -------------------------------------------------------
+
+    def _pick_color(self, room: Room) -> str:
+        taken = {p.color for p in room.peers.values()}
+        for color in PALETTE:
+            if color not in taken:
+                return color
+        return PALETTE[len(room.peers) % len(PALETTE)]
+
+    def join(self, *, room_name: str, ws: WebSocket, ip: str) -> Peer:
+        """Admit a connection, or raise ``JoinRejected`` saying which cap it hit.
+
+        Order matters: the global cap is checked first because it is the one that
+        protects the process, then the per-IP cap (one person's tabs must not
+        crowd out everyone else), then the room. Creating a room is itself capped
+        — otherwise a single client could mint 100 000 rooms from a query string.
+        """
+        if self._total >= settings.cursor_max_connections:
+            raise JoinRejected("server_full", CLOSE_TRY_LATER)
+        if self._per_ip.get(ip, 0) >= settings.cursor_max_per_ip:
+            raise JoinRejected("too_many_connections", CLOSE_POLICY)
+
+        room = self._rooms.get(room_name)
+        if room is None:
+            if len(self._rooms) >= settings.cursor_max_rooms:
+                raise JoinRejected("too_many_rooms", CLOSE_TRY_LATER)
+            room = Room(name=room_name)
+            self._rooms[room_name] = room
+        elif len(room.peers) >= settings.cursor_max_per_room:
+            raise JoinRejected("room_full", CLOSE_TRY_LATER)
+
+        peer = Peer(
+            id=uuid.uuid4().hex[:12],
+            color=self._pick_color(room),
+            ip=ip,
+            ws=ws,
+            room=room_name,
+            queue=asyncio.Queue(maxsize=settings.cursor_send_queue_size),
+            bucket=_TokenBucket(
+                rate=settings.cursor_max_messages_per_second,
+                burst=settings.cursor_max_messages_per_second * 2,
+            ),
+        )
+        room.peers[peer.id] = peer
+        self._per_ip[ip] = self._per_ip.get(ip, 0) + 1
+        self._total += 1
+
+        # Started only once the room has someone in it, and stopped again when it
+        # empties — an idle loop per abandoned room is exactly the kind of leak
+        # that only shows up after a month of uptime.
+        if room.task is None:
+            room.task = asyncio.create_task(self._broadcast_loop(room))
+        return peer
+
+    def leave(self, peer: Peer) -> None:
+        """Remove a peer and tear the room down if it was the last one.
+
+        Written to be safe to call twice: the disconnect path and the error path
+        both end here, and a double-decrement of ``_total`` would slowly leak
+        capacity until the endpoint refused everyone.
+        """
+        room = self._rooms.get(peer.room)
+        if room is None or room.peers.pop(peer.id, None) is None:
+            return
+
+        self._total -= 1
+        remaining = self._per_ip.get(peer.ip, 0) - 1
+        if remaining > 0:
+            self._per_ip[peer.ip] = remaining
+        else:
+            self._per_ip.pop(peer.ip, None)
+
+        if not room.peers:
+            if room.task is not None:
+                room.task.cancel()
+            del self._rooms[peer.room]
+
+    def snapshot(self, room_name: str, *, exclude: str) -> list[dict]:
+        """Everyone currently in the room except ``exclude``, with their positions."""
+        room = self._rooms.get(room_name)
+        if room is None:
+            return []
+        return [
+            {"id": p.id, "color": p.color, "x": round(p.x, 4), "y": round(p.y, 4)}
+            for p in room.peers.values()
+            if p.id != exclude
+        ]
+
+    def send_to(self, peer: Peer, payload: str) -> None:
+        """Queue one frame for a single peer (used for welcome and pong)."""
+        self._enqueue(peer, payload)
+
+    # -- delivery ---------------------------------------------------------
+
+    def _enqueue(self, peer: Peer, payload: str) -> None:
+        """Hand a frame to one peer, or mark it unreachable.
+
+        Never awaits. ``await ws.send_text`` on a stalled client blocks for as
+        long as the client feels like, and doing that from the room's broadcast
+        loop would let one bad socket freeze the room for everyone in it.
+        """
+        if peer.stalled:
+            return
+        try:
+            peer.queue.put_nowait(payload)
+        except asyncio.QueueFull:
+            # Closing is what ends the connection, not cancelling the writer: the
+            # reader is parked in receive_text() and only a closed socket wakes it.
+            # Left alone it would hold its slot until TCP gives up, which on a
+            # half-open connection is minutes.
+            logger.info("cursor peer %s fell behind, dropping", peer.id)
+            peer.stalled = True
+            _cancel_writer(peer)
+            _detach(asyncio.create_task(_close_quietly(peer.ws, CLOSE_TRY_LATER)))
+
+    def broadcast(self, room_name: str, payload: str, *, skip: str | None = None) -> None:
+        room = self._rooms.get(room_name)
+        if room is None:
+            return
+        # list() because _enqueue can drop a peer, and mutating during iteration
+        # would raise and abort delivery to everyone after it.
+        for peer in list(room.peers.values()):
+            if peer.id != skip:
+                self._enqueue(peer, payload)
+
+    async def _broadcast_loop(self, room: Room) -> None:
+        """Emit one combined frame per tick, containing only peers that moved.
+
+        Everyone gets the same bytes, including their own cursor. Filtering each
+        peer out of its own frame would mean serialising the payload once per
+        peer instead of once per room; the client already knows its own id from
+        the welcome message and drops it in one line.
+        """
+        interval = 1.0 / settings.cursor_tick_hz
+        try:
+            while True:
+                await asyncio.sleep(interval)
+                movers = {}
+                for peer in room.peers.values():
+                    if peer.moved:
+                        # 4 decimals is ~0.1 px on a 1000 px axis: below what a
+                        # screen can show, and it keeps the frame small.
+                        movers[peer.id] = [round(peer.x, 4), round(peer.y, 4)]
+                        peer.moved = False
+                if movers:
+                    self.broadcast(room.name, json.dumps({"t": "frame", "c": movers}))
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            # A crashed loop leaves the room silently frozen — connected, sending,
+            # and nobody seeing anything. Log it rather than let the task die mute.
+            logger.exception("cursor broadcast loop for room %r stopped", room.name)
+            raise
+
+    async def shutdown(self) -> None:
+        """Stop every room loop and close whatever sockets are still open.
+
+        By the time uvicorn runs this the sockets are usually already closed —
+        it shuts connections down before firing lifespan shutdown — so the close
+        below is for the cases where that is not true: the ``--reload`` path in
+        development, and the tests. The part that always matters is cancelling
+        the room tasks, which uvicorn knows nothing about.
+        """
+        for room in list(self._rooms.values()):
+            if room.task is not None:
+                room.task.cancel()
+            for peer in list(room.peers.values()):
+                _cancel_writer(peer)
+                with contextlib.suppress(Exception):
+                    if peer.ws.client_state is WebSocketState.CONNECTED:
+                        await peer.ws.close(code=1001)  # going away
+        self._rooms.clear()
+        self._per_ip.clear()
+        self._total = 0
+
+
+hub = CursorHub()
+
+# Writer tasks are tracked beside the peer rather than on it so that Peer stays a
+# plain data record with no asyncio machinery in its repr (peers get logged).
+_writers: dict[str, asyncio.Task] = {}
+
+# asyncio keeps only a weak reference to a running task, so a fire-and-forget one
+# can be garbage-collected mid-await. Holding it here until it finishes is the
+# documented way to stop that.
+_background: set[asyncio.Task] = set()
+
+
+def _detach(task: asyncio.Task) -> None:
+    _background.add(task)
+    task.add_done_callback(_background.discard)
+
+
+async def _close_quietly(ws: WebSocket, code: int) -> None:
+    with contextlib.suppress(Exception):
+        if ws.client_state is WebSocketState.CONNECTED:
+            await ws.close(code=code)
+
+
+def _cancel_writer(peer: Peer) -> None:
+    task = _writers.pop(peer.id, None)
+    if task is not None:
+        task.cancel()
+
+
+async def _writer(peer: Peer) -> None:
+    """Drain one peer's queue onto its socket.
+
+    One task per connection, so a slow or half-open socket blocks only itself.
+    """
+    try:
+        while True:
+            payload = await peer.queue.get()
+            await peer.ws.send_text(payload)
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        # Sending to a socket the client already dropped is routine, not an
+        # error worth a stack trace; the reader will notice and clean up.
+        logger.debug("cursor writer for %s ended", peer.id)
+
+
+def _valid_room(raw: str | None) -> str | None:
+    """Normalise and validate the requested room, or None if it is unusable."""
+    name = (raw or DEFAULT_ROOM).strip()
+    if not name:
+        name = DEFAULT_ROOM
+    return name if _ROOM_RE.match(name) else None
+
+
+def _coord(value: object) -> float | None:
+    """A pointer coordinate as a fraction of the viewport, or None if unusable.
+
+    Clamped rather than rejected: a pointer legitimately leaves the viewport
+    during a drag, and dropping the connection over an x of 1.0002 would be a
+    bug that only shows up on someone else's trackpad. NaN and infinity *are*
+    rejected — they survive json.loads, pass a naive range check (every
+    comparison against NaN is False), and would poison the frame for every peer.
+    """
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return None
+    number = float(value)
+    if not math.isfinite(number):
+        return None
+    return min(1.0, max(0.0, number))
+
+
+@router.get("/cursors/stats")
+def cursor_stats():
+    """Aggregate load, for a healthcheck or a dashboard.
+
+    Aggregate only: a per-room breakdown would turn an unauthenticated endpoint
+    into a live feed of which pages are being read right now, which is precisely
+    the visitor data the rest of this service is careful not to publish.
+    """
+    return {
+        "connections": hub.connections,
+        "rooms": hub.room_count,
+        "max_connections": settings.cursor_max_connections,
+    }
+
+
+@router.websocket("/ws/cursors")
+async def cursors_ws(websocket: WebSocket):
+    """Cursor presence for one room. See module docstring for the protocol."""
+    origin = websocket.headers.get("origin")
+    if not is_allowed_origin(origin):
+        # Closing before accept() answers the handshake with an HTTP 403, so the
+        # rejection is visible in the browser's network tab instead of appearing
+        # as a connection that opens and instantly dies.
+        logger.warning("cursor ws rejected: origin=%r", origin)
+        await websocket.close(code=CLOSE_POLICY)
+        return
+
+    room_name = _valid_room(websocket.query_params.get("room"))
+    if room_name is None:
+        await websocket.close(code=CLOSE_POLICY)
+        return
+
+    await websocket.accept()
+    ip = client_ip(websocket)
+
+    try:
+        peer = hub.join(room_name=room_name, ws=websocket, ip=ip)
+    except JoinRejected as rejected:
+        # Accepted first, so the reason can be delivered. A bare close code tells
+        # the frontend nothing about whether retrying is worth it.
+        with contextlib.suppress(Exception):
+            await websocket.send_text(json.dumps({"t": "error", "code": rejected.reason}))
+            await websocket.close(code=rejected.close_code)
+        return
+
+    _writers[peer.id] = asyncio.create_task(_writer(peer))
+
+    # Full room state, once, at join. Every later message is a delta, which is
+    # only coherent because the client starts from this snapshot.
+    hub.send_to(
+        peer,
+        json.dumps(
+            {
+                "t": "welcome",
+                "id": peer.id,
+                "color": peer.color,
+                "room": room_name,
+                "peers": hub.snapshot(room_name, exclude=peer.id),
+                "tick_hz": settings.cursor_tick_hz,
+                "idle_timeout_seconds": settings.cursor_idle_timeout_seconds,
+            }
+        ),
+    )
+    hub.broadcast(
+        room_name,
+        json.dumps({"t": "join", "id": peer.id, "color": peer.color}),
+        skip=peer.id,
+    )
+
+    try:
+        await _read_loop(peer, websocket)
+    except WebSocketDisconnect:
+        pass
+    except Exception:
+        logger.exception("cursor ws for %s failed", peer.id)
+    finally:
+        _cancel_writer(peer)
+        # leave() first, so the departing peer isn't among the recipients of its
+        # own leave message — and so the slot is freed even if broadcasting fails.
+        hub.leave(peer)
+        hub.broadcast(room_name, json.dumps({"t": "leave", "id": peer.id}))
+        await _close_quietly(websocket, 1000)
+
+
+async def _read_loop(peer: Peer, websocket: WebSocket) -> None:
+    """Consume client frames until it disconnects, idles out, or misbehaves."""
+    idle = settings.cursor_idle_timeout_seconds
+    while True:
+        try:
+            raw = await asyncio.wait_for(websocket.receive_text(), timeout=idle)
+        except TimeoutError:
+            # Not a failure: a backgrounded tab stops pinging, and a tab nobody
+            # is looking at is not a cursor anyone needs to see. Freeing the slot
+            # is the point.
+            logger.debug("cursor peer %s idled out", peer.id)
+            return
+
+        if not peer.bucket.take():
+            logger.info("cursor peer %s exceeded the inbound rate, closing", peer.id)
+            await websocket.close(code=CLOSE_POLICY)
+            return
+
+        # Oversized frames are counted as invalid rather than parsed: json.loads
+        # on an attacker-sized string is the work we are trying to avoid doing.
+        peer.invalid_frames = (
+            peer.invalid_frames + 1 if len(raw) > _MAX_FRAME_CHARS else _handle_frame(peer, raw)
+        )
+
+        if peer.stalled:
+            # Already given up on by the broadcast loop (see _enqueue). Return so
+            # the caller's finally block runs and the slot is actually released.
+            return
+
+        if peer.invalid_frames >= _MAX_INVALID_FRAMES:
+            logger.info("cursor peer %s sent only garbage, closing", peer.id)
+            await websocket.close(code=CLOSE_POLICY)
+            return
+
+
+def _handle_frame(peer: Peer, raw: str) -> int:
+    """Apply one client frame. Returns the peer's new invalid-frame count.
+
+    Movement is recorded, never forwarded: the room's tick loop is what actually
+    sends it. That is the whole reason a client cannot flood the room by
+    flooding us.
+    """
+    try:
+        message = json.loads(raw)
+    except (ValueError, TypeError):
+        return peer.invalid_frames + 1
+    if not isinstance(message, dict):
+        return peer.invalid_frames + 1
+
+    kind = message.get("t")
+    if kind == "cursor":
+        x = _coord(message.get("x"))
+        y = _coord(message.get("y"))
+        if x is None or y is None:
+            return peer.invalid_frames + 1
+        peer.x, peer.y, peer.moved = x, y, True
+        return 0
+    if kind == "ping":
+        # Round-trip for the client's own liveness check, and what keeps an
+        # active tab from tripping the idle timeout. Routed through the hub so a
+        # peer whose queue is already full gets dropped here too, rather than
+        # having its pong silently swallowed while it believes it is connected.
+        hub.send_to(peer, json.dumps({"t": "pong"}))
+        return 0
+    return peer.invalid_frames + 1

--- a/apps/site/cursors.py
+++ b/apps/site/cursors.py
@@ -488,7 +488,13 @@ async def cursors_ws(websocket: WebSocket):
         # the frontend nothing about whether retrying is worth it.
         with contextlib.suppress(Exception):
             await websocket.send_text(json.dumps({"t": "error", "code": rejected.reason}))
-            await websocket.close(code=rejected.close_code)
+        # Closed outside that suppress, and it matters: if the client vanished
+        # between accept() and the error frame, sharing one suppress would skip
+        # the close entirely. uvicorn tears the socket down regardless, but with
+        # 1006 (abnormal) — the one code a client reads as "network glitch, retry".
+        # A peer refused on policy would then reconnect forever against a cap
+        # that will never let it in.
+        await _close_quietly(websocket, rejected.close_code)
         return
 
     _writers[peer.id] = asyncio.create_task(_writer(peer))

--- a/apps/site/main.py
+++ b/apps/site/main.py
@@ -1,32 +1,60 @@
-"""Site service — a lightweight beacon the frontend pings on page load.
+"""Site service — everything the public frontend talks to directly.
 
-When a *new* visitor arrives it pushes a notification via the pluggable notifier
-(ntfy today, more later). Historical analytics live in Umami; this is only the
-real-time "someone's here" ping. No DB — throttling is in-memory, which is fine
-for this single-worker deployment.
+Two features, both about who is on the site right now:
+
+* ``POST /site/visit`` — a beacon the frontend pings on page load. A *new*
+  visitor pushes a notification through the pluggable notifier (ntfy today).
+  Historical analytics live in Umami; this is only the "someone's here" ping.
+* ``WS /site/ws/cursors`` — live cursor presence, so visitors on the same page
+  see each other's pointers. See ``apps.site.cursors``.
+
+Neither touches the DB: throttling and presence are in-memory, which is correct
+for this single-worker deployment and nowhere else.
 """
 
 import ipaddress
 import logging
 import time
 from collections import OrderedDict
+from contextlib import asynccontextmanager
 from urllib.parse import parse_qs, urlsplit
 
 import httpx
-from fastapi import APIRouter, BackgroundTasks, Request
+from fastapi import APIRouter, BackgroundTasks, FastAPI, Request
 from pydantic import BaseModel, Field
 
 from apps.shared.app_factory import create_app, include_versioned
 from apps.shared.config import settings
 from apps.shared.net import client_ip
 from apps.shared.notifications import notifier
+from apps.site import cursors
 
 logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def lifespan(_: FastAPI):
+    """Stop the per-room broadcast loops on shutdown.
+
+    Not the sockets: uvicorn closes those itself, and does it *before* it runs
+    lifespan shutdown (``Server.shutdown`` calls ``connection.shutdown()`` on
+    every connection, then waits, then fires this). What it does not know about
+    are the ``asyncio`` tasks this app started on its own — one per active room.
+    Left running they keep ticking against peers that are already gone, and the
+    loop is torn down mid-await at interpreter exit instead of cancelled cleanly.
+
+    This also matters under ``--reload`` in development, where the process is not
+    exiting at all: without it every reload leaks another set of room loops.
+    """
+    yield
+    await cursors.hub.shutdown()
+
 
 app = create_app(
     title="Site Service",
     url_prefix="site",
-    description="Visitor beacon that pushes a notification on a new visit",
+    description="Visitor beacon and live cursor presence for the public site",
+    lifespan=lifespan,
 )
 router = APIRouter(prefix="/site")
 
@@ -188,3 +216,6 @@ def visit(payload: VisitIn, request: Request, background_tasks: BackgroundTasks)
 
 
 include_versioned(app, router)
+# Mounted the same way, so the cursor endpoint answers on both /site/ws/cursors
+# and /v1/site/ws/cursors and matches every other route's versioning contract.
+include_versioned(app, cursors.router)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -75,6 +75,15 @@ services:
     ports:
       - "127.0.0.1:5005:5005"
 
+  # The site service was previously prod-only, which made the visit beacon and
+  # the cursor WebSocket impossible to try locally. It needs no database, but it
+  # inherits the base anyway so it gets the source bind-mount and --reload.
+  site-api:
+    <<: *app-base
+    command: ["uvicorn", "apps.site.main:app", "--host", "0.0.0.0", "--port", "5006", "--reload", "--proxy-headers", "--forwarded-allow-ips", "*", "--timeout-graceful-shutdown", "5"]
+    ports:
+      - "127.0.0.1:5006:5006"
+
 networks:
   backend:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -141,7 +141,12 @@ services:
   # Visitor beacon → pushes a notification on a new visit (no DB; ntfy via config).
   site-api:
     image: ghcr.io/vuhnger/backend:${BACKEND_TAG:-latest}
-    command: ["uvicorn", "apps.site.main:app", "--host", "0.0.0.0", "--port", "5006", "--proxy-headers", "--forwarded-allow-ips", "*"]
+    # --timeout-graceful-shutdown is here and nowhere else: uvicorn's default is
+    # to wait indefinitely for open connections, which is harmless for request/
+    # response services but not for one holding WebSockets. A single client that
+    # ignores the close frame would otherwise pin the container until Docker's
+    # SIGKILL at 10s, turning every deploy into a hard kill.
+    command: ["uvicorn", "apps.site.main:app", "--host", "0.0.0.0", "--port", "5006", "--proxy-headers", "--forwarded-allow-ips", "*", "--timeout-graceful-shutdown", "5"]
     restart: unless-stopped
     ports:
       - "127.0.0.1:5006:5006"
@@ -156,6 +161,24 @@ services:
       NTFY_URL: ${NTFY_URL}
       VISIT_NOTIFY_THROTTLE_SECONDS: ${VISIT_NOTIFY_THROTTLE_SECONDS:-3600}
       VISIT_NOTIFY_EXCLUDE_IPS: ${VISIT_NOTIFY_EXCLUDE_IPS:-}
+
+      # CORS origin list for the cursor WebSocket. Same list as HTTP — this
+      # service has no env_file, so a name not spelled out here never reaches
+      # the container and the origin check silently falls back to the defaults.
+      FRONTEND_URL: ${FRONTEND_URL:-https://vuhnger.dev}
+
+      # Live cursor presence. Defaults in apps/shared/config.py are sized for
+      # this box; they are here so they can be turned down without a redeploy.
+      # Note the uvicorn command above runs a single worker, which the in-memory
+      # hub requires: a second worker would split the rooms in half.
+      CURSOR_MAX_CONNECTIONS: ${CURSOR_MAX_CONNECTIONS:-200}
+      CURSOR_MAX_PER_ROOM: ${CURSOR_MAX_PER_ROOM:-50}
+      CURSOR_MAX_PER_IP: ${CURSOR_MAX_PER_IP:-5}
+      CURSOR_MAX_ROOMS: ${CURSOR_MAX_ROOMS:-100}
+      CURSOR_TICK_HZ: ${CURSOR_TICK_HZ:-15}
+      CURSOR_MAX_MESSAGES_PER_SECOND: ${CURSOR_MAX_MESSAGES_PER_SECOND:-60}
+      CURSOR_IDLE_TIMEOUT_SECONDS: ${CURSOR_IDLE_TIMEOUT_SECONDS:-900}
+      CURSOR_SEND_QUEUE_SIZE: ${CURSOR_SEND_QUEUE_SIZE:-64}
     networks:
       - backend
 

--- a/frontend-examples/README.md
+++ b/frontend-examples/README.md
@@ -102,3 +102,100 @@ export async function getHealth(): Promise<HealthResponse> {
 - Only the health endpoint is functional
 - Future endpoints are commented out as examples
 - DO NOT implement calendar features until backend is ready
+
+---
+
+# Live cursors (`WS /site/ws/cursors`)
+
+Multiplayer cursors: everyone on the same page sees everyone else's pointer.
+`src/hooks/useCursors.ts` is a working client — the rest of this section is the
+contract it implements, for when you want to write your own.
+
+## Connecting
+
+```
+wss://api.vuhnger.dev/site/ws/cursors?room=<room>
+```
+
+`room` is the presence scope — peers only see each other inside the same room.
+Pass `location.pathname` for per-page presence, or a constant for one shared
+room. It defaults to `/`, may be at most 64 characters, and is restricted to
+`A-Z a-z 0-9 / _ . -`; anything else is refused at the handshake.
+
+`/v1/site/ws/cursors` is the same endpoint under the versioned prefix.
+
+The `Origin` header is checked against the same allowlist as CORS. That check is
+not redundant with CORS: browsers send `Origin` on a WebSocket handshake but
+enforce nothing themselves, so without it any site could open this channel.
+
+## Messages
+
+Client → server:
+
+| Message | Meaning |
+| --- | --- |
+| `{"t":"cursor","x":0.51,"y":0.28}` | Pointer position, as **fractions of the viewport**. Values outside `[0,1]` are clamped, not rejected. |
+| `{"t":"ping"}` | Answered with `{"t":"pong"}`. Also what keeps an idle tab from being closed. |
+
+Server → client:
+
+| Message | Meaning |
+| --- | --- |
+| `{"t":"welcome","id":..,"color":"#e11d48","room":..,"peers":[..],"tick_hz":15,"idle_timeout_seconds":900}` | First message. `peers` is the full room state; everything after it is a delta. |
+| `{"t":"join","id":..,"color":..}` | Someone arrived. |
+| `{"t":"leave","id":..}` | Someone left. |
+| `{"t":"frame","c":{"<id>":[x,y]}}` | Positions that changed since the last tick. |
+| `{"t":"pong"}` | Reply to your ping. |
+| `{"t":"error","code":".."}` | Sent just before a close, explaining it. |
+
+**Coordinates are viewport fractions, not pixels**, so a phone and a 4K monitor
+agree on where the cursor is. Multiply by the container's size to draw.
+
+**`frame` includes your own cursor.** The same bytes go to the whole room rather
+than being re-serialised per recipient; drop your own id (from `welcome`).
+
+**`frame` only contains peers that moved.** A still room sends nothing at all.
+
+## Colour
+
+The server assigns each peer a colour, unique within the room while both are in
+it, so all clients agree on who is who — two browsers picking their own would
+sometimes pick the same one. Ignore it and use your own if you prefer.
+
+## Rate and pacing
+
+The server batches: it collects positions and emits one combined frame at
+`tick_hz` (15 by default), so sending faster than that gains nothing — the extra
+samples are collapsed into the same frame. Sample `pointermove` into a variable
+and send on a timer. Above 60 messages/second the connection is closed.
+
+## Closes, and which ones to retry
+
+| Code | Meaning | Retry? |
+| --- | --- | --- |
+| `1008` | Policy: bad origin, bad room name, too many tabs from your IP, or a stream of malformed frames. | **No.** Nothing about retrying changes the answer. |
+| `1013` | Full: the server, the room, or the room count is at capacity. | Yes, with backoff. |
+| `1012` | Server restarting (deploy). Sent by uvicorn itself, which closes
+connections before the app's own shutdown hook runs — so `1001` appears only
+under `--reload` in development. | Yes, with backoff. |
+| `1000` | Normal close. | — |
+
+Back off exponentially **with jitter**. The interesting failure is a restart,
+when every open tab reconnects at once; a fixed delay makes them all arrive
+together and turns a 5-second deploy into a thundering herd.
+
+## Idle
+
+A connection that sends nothing for `idle_timeout_seconds` (15 min) is closed.
+That is deliberate — a tab nobody is looking at is not presence. Ping every 30 s
+while `document.hidden` is false and a backgrounded tab drops out on its own.
+
+## Limits
+
+Defaults, all tunable per environment (`CURSOR_*` in `docker-compose.yml`):
+200 connections total, 50 per room, 5 per IP, 100 rooms.
+`GET /site/cursors/stats` returns the aggregate load.
+
+The hub is in-memory and **single-worker**: two uvicorn workers would split each
+room in half and peers would stop seeing each other. Scaling past one worker
+means a Redis pub/sub backend, not a bigger box.

--- a/frontend-examples/README.md
+++ b/frontend-examples/README.md
@@ -97,11 +97,15 @@ export async function getHealth(): Promise<HealthResponse> {
 
 ## ⚠️ Important Notes
 
-- These are **placeholder/boilerplate files only**
-- No business logic implemented yet
-- Only the health endpoint is functional
-- Future endpoints are commented out as examples
-- DO NOT implement calendar features until backend is ready
+These apply to the **calendar** files above, not to the whole directory:
+
+- `api/calendar.ts`, `api/types.ts` and `components/HealthCheck.tsx` are
+  **placeholder/boilerplate only** — of those, just the health endpoint works
+- Future calendar endpoints are commented out as examples
+- DO NOT implement calendar features until the backend is ready
+
+`hooks/useCursors.ts` is not boilerplate: it is a working client for the
+endpoint documented below.
 
 ---
 
@@ -175,10 +179,16 @@ and send on a timer. Above 60 messages/second the connection is closed.
 | --- | --- | --- |
 | `1008` | Policy: bad origin, bad room name, too many tabs from your IP, or a stream of malformed frames. | **No.** Nothing about retrying changes the answer. |
 | `1013` | Full: the server, the room, or the room count is at capacity. | Yes, with backoff. |
-| `1012` | Server restarting (deploy). Sent by uvicorn itself, which closes
-connections before the app's own shutdown hook runs — so `1001` appears only
-under `--reload` in development. | Yes, with backoff. |
-| `1000` | Normal close. | — |
+| `1012` | Server restarting (deploy). Uvicorn sends this itself — it closes connections before the app's own shutdown hook runs, so `1001` shows up only under `--reload` in development. | Yes, with backoff. |
+| `1000` | Normal close, including the idle timeout below. | Yes, with backoff. |
+| `1006` | Abnormal — the socket died without a close frame. | Yes, with backoff. |
+
+Everything except `1008` is worth retrying, which is what `useCursors.ts` does.
+A consequence worth knowing: a backgrounded tab is closed with `1000` after the
+idle timeout, reconnects, goes idle again, and repeats — one handshake every 15
+minutes per abandoned tab. That is cheap enough to accept, and the per-IP cap
+bounds it; reconnecting only on `visibilitychange` would avoid it entirely if it
+ever stops being cheap.
 
 Back off exponentially **with jitter**. The interesting failure is a restart,
 when every open tab reconnects at once; a fixed delay makes them all arrive

--- a/frontend-examples/src/hooks/useCursors.ts
+++ b/frontend-examples/src/hooks/useCursors.ts
@@ -101,12 +101,21 @@ export function useCursors(options: UseCursorsOptions = {}): UseCursorsResult {
       const socket = new WebSocket(url);
       socketRef.current = socket;
 
+      // Every callback below is gated on this. A socket's events keep arriving
+      // after it has been superseded — change `room` and the old socket's
+      // `onclose` fires *after* the new one has already opened, so an ungated
+      // setConnected(false) would report the live connection as dead, and a
+      // late `frame` would write the old room's peers over the new room's.
+      const current = () => !closed && socketRef.current === socket;
+
       socket.onopen = () => {
+        if (!current()) return;
         retry = 0;
         setConnected(true);
       };
 
       socket.onmessage = (event) => {
+        if (!current()) return;
         const message: ServerMessage = JSON.parse(event.data);
         switch (message.t) {
           case 'welcome':
@@ -137,8 +146,13 @@ export function useCursors(options: UseCursorsOptions = {}): UseCursorsResult {
       };
 
       socket.onclose = (event) => {
+        if (!current()) return;
         setConnected(false);
-        if (closed) return;
+        // Presence is not durable across a disconnect: the peers list describes
+        // who is in the room *right now*, and leaving it on screen paints
+        // cursors for people who may have gone. The next welcome rebuilds it.
+        setPeers([]);
+        setSelf(null);
         // 1008 is a policy refusal — a bad origin, a bad room, or too many tabs
         // from this address. Retrying cannot change any of those, and hammering
         // a rejection is how a cap turns into a self-inflicted outage.
@@ -193,6 +207,13 @@ export function useCursors(options: UseCursorsOptions = {}): UseCursorsResult {
       window.clearInterval(pingTimer);
       socketRef.current?.close(1000, 'unmounted');
       socketRef.current = null;
+      // Cleared here too, not just in onclose: on unmount or a room change the
+      // close is ours, and `closed` already gated onclose out. Without this the
+      // old room's cursors survive into the new one.
+      pending.current = null;
+      setPeers([]);
+      setSelf(null);
+      setConnected(false);
     };
   }, [room, sendHz, enabled]);
 

--- a/frontend-examples/src/hooks/useCursors.ts
+++ b/frontend-examples/src/hooks/useCursors.ts
@@ -1,0 +1,200 @@
+/**
+ * Live cursor presence — see everyone else's pointer on the same page.
+ *
+ * Connects to `WS /site/ws/cursors`, streams this tab's pointer position, and
+ * returns the other peers currently in the room.
+ *
+ * Two things the backend deliberately leaves to you:
+ *
+ *  - *Rendering.* You get a colour and a position per peer; how a cursor looks,
+ *    and whether you interpolate between frames, is yours.
+ *  - *Choosing the room.* Peers only see each other inside the same room, so the
+ *    room name is what decides "same page" — pass `location.pathname` for
+ *    per-page presence, or a constant for one shared room across the whole site.
+ *
+ * Coordinates are fractions of the viewport, not pixels: a phone and a 4K
+ * monitor have to agree on where the cursor is. Multiply back by the container's
+ * size when you draw.
+ *
+ * @example
+ *   const { peers, self } = useCursors({ room: location.pathname });
+ *   return peers.map(p => (
+ *     <div key={p.id} style={{
+ *       position: 'fixed', left: `${p.x * 100}%`, top: `${p.y * 100}%`,
+ *       background: p.color, transition: 'left 80ms linear, top 80ms linear',
+ *     }} />
+ *   ));
+ */
+
+import { useEffect, useRef, useState } from 'react';
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL ?? 'https://api.vuhnger.dev';
+
+export interface Peer {
+  id: string;
+  /** Server-assigned, unique within the room while you are both in it. */
+  color: string;
+  /** Viewport fractions in [0, 1]. */
+  x: number;
+  y: number;
+}
+
+export interface UseCursorsOptions {
+  /** Presence scope. Peers only see each other within the same room. */
+  room?: string;
+  /**
+   * Pointer samples sent per second. There is no point exceeding the server's
+   * broadcast rate (`tick_hz`, 15 by default) — anything above it is collapsed
+   * into the same frame and only costs the visitor's battery.
+   */
+  sendHz?: number;
+  enabled?: boolean;
+}
+
+export interface UseCursorsResult {
+  peers: Peer[];
+  /** This tab's own id and colour, or null until the socket is open. */
+  self: { id: string; color: string } | null;
+  connected: boolean;
+}
+
+type ServerMessage =
+  | { t: 'welcome'; id: string; color: string; room: string; peers: Peer[]; tick_hz: number; idle_timeout_seconds: number }
+  | { t: 'join'; id: string; color: string }
+  | { t: 'leave'; id: string }
+  | { t: 'frame'; c: Record<string, [number, number]> }
+  | { t: 'pong' }
+  | { t: 'error'; code: string };
+
+/** Close codes the server uses to say "full, but you may come back". */
+const RETRYABLE_CLOSE = 1013;
+
+export function useCursors(options: UseCursorsOptions = {}): UseCursorsResult {
+  const { room = '/', sendHz = 15, enabled = true } = options;
+
+  const [peers, setPeers] = useState<Peer[]>([]);
+  const [self, setSelf] = useState<{ id: string; color: string } | null>(null);
+  const [connected, setConnected] = useState(false);
+
+  const socketRef = useRef<WebSocket | null>(null);
+  // Latest pointer position, sampled on a timer rather than sent on every
+  // mousemove: a trackpad fires 100+ events a second and the server collapses
+  // them anyway, so sending each one is pure waste on both ends.
+  const pending = useRef<{ x: number; y: number } | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    let closed = false;
+    let retry = 0;
+    let reconnectTimer: number | undefined;
+    let sendTimer: number | undefined;
+    let pingTimer: number | undefined;
+
+    const connect = () => {
+      if (closed) return;
+
+      const url = new URL('/site/ws/cursors', API_BASE);
+      url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+      url.searchParams.set('room', room);
+
+      const socket = new WebSocket(url);
+      socketRef.current = socket;
+
+      socket.onopen = () => {
+        retry = 0;
+        setConnected(true);
+      };
+
+      socket.onmessage = (event) => {
+        const message: ServerMessage = JSON.parse(event.data);
+        switch (message.t) {
+          case 'welcome':
+            setSelf({ id: message.id, color: message.color });
+            setPeers(message.peers);
+            break;
+          case 'join':
+            setPeers((prev) => [...prev, { id: message.id, color: message.color, x: 0.5, y: 0.5 }]);
+            break;
+          case 'leave':
+            setPeers((prev) => prev.filter((p) => p.id !== message.id));
+            break;
+          case 'frame':
+            // One frame carries every peer that moved this tick, including you —
+            // the server sends identical bytes to the whole room rather than
+            // re-serialising it per recipient. Your own id is dropped here.
+            setPeers((prev) =>
+              prev.map((p) => {
+                const moved = message.c[p.id];
+                return moved ? { ...p, x: moved[0], y: moved[1] } : p;
+              }),
+            );
+            break;
+          case 'error':
+            console.warn('[cursors] refused:', message.code);
+            break;
+        }
+      };
+
+      socket.onclose = (event) => {
+        setConnected(false);
+        if (closed) return;
+        // 1008 is a policy refusal — a bad origin, a bad room, or too many tabs
+        // from this address. Retrying cannot change any of those, and hammering
+        // a rejection is how a cap turns into a self-inflicted outage.
+        if (event.code === 1008) {
+          console.warn('[cursors] refused by server, not retrying:', event.reason);
+          return;
+        }
+        // Exponential backoff with jitter, capped at 30s. Jitter matters: the
+        // interesting failure is the server restarting, when every open tab is
+        // reconnecting at once and a fixed delay makes them all arrive together.
+        const delay = Math.min(30_000, 500 * 2 ** retry) * (0.5 + Math.random());
+        retry = Math.min(retry + 1, 6);
+        if (event.code === RETRYABLE_CLOSE) console.info('[cursors] server full, retrying');
+        reconnectTimer = window.setTimeout(connect, delay);
+      };
+    };
+
+    const onPointerMove = (event: PointerEvent) => {
+      pending.current = {
+        x: event.clientX / window.innerWidth,
+        y: event.clientY / window.innerHeight,
+      };
+    };
+
+    sendTimer = window.setInterval(() => {
+      const socket = socketRef.current;
+      const next = pending.current;
+      if (!next || socket?.readyState !== WebSocket.OPEN) return;
+      pending.current = null;
+      socket.send(JSON.stringify({ t: 'cursor', x: next.x, y: next.y }));
+    }, 1000 / sendHz);
+
+    // Keeps an open-but-still tab alive. The server closes connections that go
+    // quiet for `idle_timeout_seconds` (15 min), which is deliberate: a tab
+    // nobody is looking at should not occupy a slot. document.hidden is the
+    // whole mechanism — a backgrounded tab stops pinging and drops out on its own.
+    pingTimer = window.setInterval(() => {
+      const socket = socketRef.current;
+      if (socket?.readyState === WebSocket.OPEN && !document.hidden) {
+        socket.send(JSON.stringify({ t: 'ping' }));
+      }
+    }, 30_000);
+
+    window.addEventListener('pointermove', onPointerMove, { passive: true });
+    connect();
+
+    return () => {
+      closed = true;
+      window.removeEventListener('pointermove', onPointerMove);
+      window.clearTimeout(reconnectTimer);
+      window.clearInterval(sendTimer);
+      window.clearInterval(pingTimer);
+      socketRef.current?.close(1000, 'unmounted');
+      socketRef.current = null;
+    };
+  }, [room, sendHz, enabled]);
+
+  return { peers, self, connected };
+}

--- a/tests/test_cursor_presence.py
+++ b/tests/test_cursor_presence.py
@@ -1,0 +1,378 @@
+"""Live cursor presence: the hub's caps and bookkeeping, and the wire protocol.
+
+Split in two on purpose. Starlette's TestClient runs *every* WebSocket session in
+its own event loop, and ``asyncio.Queue.put_nowait`` wakes a waiting ``get()`` by
+resolving that loop's future directly — which is not safe to do from another
+thread. A two-client TestClient test therefore races, and passes or hangs by
+luck. Production has one uvicorn process and one loop, so the race cannot happen
+there; rather than harden the code against a situation it will never be in, the
+multi-peer behaviour is exercised against the hub inside a single loop, and
+TestClient is used only where one connection is enough.
+"""
+
+import asyncio
+import json
+
+import pytest
+from starlette.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect, WebSocketState
+
+import apps.shared.cors as cors
+import apps.site.cursors as cursors
+import apps.site.main as site
+from apps.site.cursors import PALETTE, CursorHub, JoinRejected, _coord, _TokenBucket, _valid_room
+
+
+class FakeWS:
+    """Just enough WebSocket for the hub: it never sends, only records."""
+
+    def __init__(self) -> None:
+        self.sent: list[str] = []
+        self.closed_with: int | None = None
+        self.client_state = WebSocketState.CONNECTED
+
+    async def send_text(self, payload: str) -> None:
+        self.sent.append(payload)
+
+    async def close(self, code: int = 1000) -> None:
+        self.closed_with = code
+        self.client_state = WebSocketState.DISCONNECTED
+
+
+@pytest.fixture
+async def hub():
+    """A fresh hub inside a running loop.
+
+    Async because ``join()`` starts the room's broadcast task, so there has to be
+    a loop to start it on — and because the teardown has to cancel those tasks,
+    or every hub test leaves a live loop behind for the next one to trip over.
+    """
+    fresh = CursorHub()
+    yield fresh
+    await fresh.shutdown()
+
+
+def drain(peer) -> list[dict]:
+    """Everything queued for a peer, decoded. Nothing is sent without a writer task."""
+    out = []
+    while not peer.queue.empty():
+        out.append(json.loads(peer.queue.get_nowait()))
+    return out
+
+
+# --- caps ------------------------------------------------------------------
+
+async def test_global_cap_rejects_with_try_later(hub, monkeypatch):
+    monkeypatch.setattr(cursors.settings, "cursor_max_connections", 2)
+    for i in range(2):
+        hub.join(room_name="/a", ws=FakeWS(), ip=f"10.0.0.{i}")
+    with pytest.raises(JoinRejected) as excinfo:
+        hub.join(room_name="/a", ws=FakeWS(), ip="10.0.0.9")
+    # try-later, not policy: the client should back off and retry, not give up.
+    assert excinfo.value.reason == "server_full"
+    assert excinfo.value.close_code == cursors.CLOSE_TRY_LATER
+
+
+async def test_per_ip_cap_does_not_block_other_visitors(hub, monkeypatch):
+    monkeypatch.setattr(cursors.settings, "cursor_max_per_ip", 2)
+    for _ in range(2):
+        hub.join(room_name="/a", ws=FakeWS(), ip="1.2.3.4")
+    with pytest.raises(JoinRejected) as excinfo:
+        hub.join(room_name="/a", ws=FakeWS(), ip="1.2.3.4")
+    assert excinfo.value.reason == "too_many_connections"
+    # The whole point of a *per-IP* cap: one person's tabs must not lock out anyone else.
+    assert hub.join(room_name="/a", ws=FakeWS(), ip="5.6.7.8") is not None
+
+
+async def test_room_cap_is_per_room_not_global(hub, monkeypatch):
+    monkeypatch.setattr(cursors.settings, "cursor_max_per_room", 1)
+    hub.join(room_name="/a", ws=FakeWS(), ip="1.1.1.1")
+    with pytest.raises(JoinRejected) as excinfo:
+        hub.join(room_name="/a", ws=FakeWS(), ip="2.2.2.2")
+    assert excinfo.value.reason == "room_full"
+    assert hub.join(room_name="/b", ws=FakeWS(), ip="3.3.3.3") is not None
+
+
+async def test_room_creation_is_capped(hub, monkeypatch):
+    """Room names come from a query param, so an uncapped dict is a memory leak
+    any single client can trigger."""
+    monkeypatch.setattr(cursors.settings, "cursor_max_rooms", 2)
+    hub.join(room_name="/a", ws=FakeWS(), ip="1.1.1.1")
+    hub.join(room_name="/b", ws=FakeWS(), ip="1.1.1.2")
+    with pytest.raises(JoinRejected) as excinfo:
+        hub.join(room_name="/c", ws=FakeWS(), ip="1.1.1.3")
+    assert excinfo.value.reason == "too_many_rooms"
+
+
+# --- bookkeeping -----------------------------------------------------------
+
+async def test_leave_frees_the_slot_and_the_room(hub):
+    peer = hub.join(room_name="/a", ws=FakeWS(), ip="1.1.1.1")
+    assert (hub.connections, hub.room_count) == (1, 1)
+    hub.leave(peer)
+    assert (hub.connections, hub.room_count) == (0, 0)
+
+
+async def test_leave_is_idempotent(hub):
+    """The disconnect path and the error path both end in leave(). A second call
+    that decremented again would leak capacity until the endpoint refused everyone."""
+    peer = hub.join(room_name="/a", ws=FakeWS(), ip="1.1.1.1")
+    hub.leave(peer)
+    hub.leave(peer)
+    assert hub.connections == 0
+    assert hub._per_ip == {}
+
+
+async def test_colors_are_distinct_within_a_room(hub):
+    peers = [hub.join(room_name="/a", ws=FakeWS(), ip=f"1.1.1.{i}") for i in range(5)]
+    assert len({p.color for p in peers}) == 5
+    assert all(p.color in PALETTE for p in peers)
+
+
+async def test_color_is_reused_once_its_owner_leaves(hub):
+    first = hub.join(room_name="/a", ws=FakeWS(), ip="1.1.1.1")
+    hub.leave(first)
+    second = hub.join(room_name="/a", ws=FakeWS(), ip="1.1.1.2")
+    assert second.color == first.color
+
+
+async def test_snapshot_excludes_the_joiner(hub):
+    a = hub.join(room_name="/a", ws=FakeWS(), ip="1.1.1.1")
+    b = hub.join(room_name="/a", ws=FakeWS(), ip="1.1.1.2")
+    ids = {entry["id"] for entry in hub.snapshot("/a", exclude=b.id)}
+    assert ids == {a.id}
+
+
+# --- delivery --------------------------------------------------------------
+
+async def test_broadcast_reaches_everyone_but_the_sender(hub):
+    a = hub.join(room_name="/a", ws=FakeWS(), ip="1.1.1.1")
+    b = hub.join(room_name="/a", ws=FakeWS(), ip="1.1.1.2")
+    hub.broadcast("/a", json.dumps({"t": "join", "id": a.id}), skip=a.id)
+    assert drain(a) == []
+    assert drain(b) == [{"t": "join", "id": a.id}]
+
+
+async def test_a_slow_peer_is_dropped_rather_than_buffered_forever(hub, monkeypatch):
+    monkeypatch.setattr(cursors.settings, "cursor_send_queue_size", 2)
+    slow = hub.join(room_name="/a", ws=FakeWS(), ip="1.1.1.1")
+    fast = hub.join(room_name="/a", ws=FakeWS(), ip="1.1.1.2")
+    for _ in range(5):
+        hub.broadcast("/a", json.dumps({"t": "frame", "c": {}}))
+        drain(fast)  # the healthy peer keeps up
+
+    assert slow.stalled is True
+    # And nothing further is queued for it — a stalled peer must stop costing memory.
+    depth = slow.queue.qsize()
+    hub.broadcast("/a", json.dumps({"t": "frame", "c": {}}))
+    assert slow.queue.qsize() == depth
+
+
+async def test_broadcast_loop_batches_only_movers(hub, monkeypatch):
+    """The whole reason fan-out is not O(n²): many moves collapse into one frame,
+    and a peer that did not move is not in it at all."""
+    monkeypatch.setattr(cursors.settings, "cursor_tick_hz", 50.0)
+    mover = hub.join(room_name="/a", ws=FakeWS(), ip="1.1.1.1")
+    still = hub.join(room_name="/a", ws=FakeWS(), ip="1.1.1.2")
+    drain(mover), drain(still)
+
+    for value in (0.1, 0.2, 0.3):  # three moves inside one tick
+        mover.x, mover.y, mover.moved = value, value, True
+    await asyncio.sleep(0.1)
+
+    frames = [m for m in drain(still) if m["t"] == "frame"]
+    assert len(frames) == 1, f"expected one batched frame, got {frames}"
+    assert frames[0]["c"] == {mover.id: [0.3, 0.3]}  # last position wins
+    assert mover.id in frames[0]["c"] and still.id not in frames[0]["c"]
+
+
+async def test_idle_room_broadcasts_nothing(hub, monkeypatch):
+    monkeypatch.setattr(cursors.settings, "cursor_tick_hz", 50.0)
+    peer = hub.join(room_name="/a", ws=FakeWS(), ip="1.1.1.1")
+    drain(peer)
+    await asyncio.sleep(0.1)
+    assert drain(peer) == []
+
+
+async def test_shutdown_closes_sockets_with_going_away(hub):
+    sockets = [FakeWS() for _ in range(3)]
+    for i, ws in enumerate(sockets):
+        hub.join(room_name="/a", ws=ws, ip=f"1.1.1.{i}")
+    await hub.shutdown()
+    assert hub.connections == 0
+    # 1001 "going away", not a silent drop: a dropped socket reads as a network
+    # fault and every tab answers it with an immediate reconnect.
+    assert [ws.closed_with for ws in sockets] == [1001, 1001, 1001]
+
+
+# --- input validation ------------------------------------------------------
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (0.5, 0.5),
+        (0, 0.0),
+        (1, 1.0),
+        (-0.2, 0.0),   # clamped: a pointer legitimately leaves the viewport
+        (1.4, 1.0),
+        (float("nan"), None),   # survives json.loads and defeats naive range checks
+        (float("inf"), None),
+        ("0.5", None),
+        (None, None),
+        (True, None),  # bool is an int subclass; a cursor at x=True is nonsense
+    ],
+)
+def test_coord_clamps_the_plausible_and_rejects_the_impossible(raw, expected):
+    assert _coord(raw) == expected
+
+
+@pytest.mark.parametrize("name", ["/", "/blog", "a-b_c.d", "/x/y/z"])
+def test_valid_room_names(name):
+    assert _valid_room(name) == name
+
+
+@pytest.mark.parametrize("name", ["with space", "x" * 65, "ny\nlinje", "emoji🎉", "sem;colon"])
+def test_invalid_room_names_are_rejected(name):
+    assert _valid_room(name) is None
+
+
+def test_missing_room_falls_back_to_default():
+    assert _valid_room(None) == cursors.DEFAULT_ROOM
+    assert _valid_room("  ") == cursors.DEFAULT_ROOM
+
+
+def test_token_bucket_allows_a_burst_then_refills():
+    bucket = _TokenBucket(rate=10.0, burst=3.0)
+    assert [bucket.take() for _ in range(4)] == [True, True, True, False]
+
+
+# --- wire protocol (single connection) -------------------------------------
+
+@pytest.fixture
+def client():
+    with TestClient(site.app) as test_client:
+        yield test_client
+    # The app singleton is shared across tests; a leaked peer would skew the caps
+    # every later test asserts on.
+    cursors.hub._rooms.clear()
+    cursors.hub._per_ip.clear()
+    cursors.hub._total = 0
+
+
+def test_welcome_carries_identity_and_the_client_side_contract(client):
+    with client.websocket_connect("/site/ws/cursors?room=/blog") as ws:
+        welcome = ws.receive_json()
+    assert welcome["t"] == "welcome"
+    assert welcome["room"] == "/blog"
+    assert welcome["color"] in PALETTE
+    assert welcome["peers"] == []
+    # Both are the frontend's contract: how often frames arrive, and how long it
+    # may stay silent before being closed. Hardcoding either in the client is how
+    # a server-side tuning change silently breaks it.
+    assert welcome["tick_hz"] > 0
+    assert welcome["idle_timeout_seconds"] > 0
+
+
+def test_cursor_update_comes_back_as_a_frame(client):
+    with client.websocket_connect("/site/ws/cursors") as ws:
+        ws.receive_json()
+        ws.send_json({"t": "cursor", "x": 0.25, "y": 0.75})
+        frame = ws.receive_json()
+    assert frame["t"] == "frame"
+    assert list(frame["c"].values()) == [[0.25, 0.75]]
+
+
+def test_out_of_range_coordinates_are_clamped_not_refused(client):
+    with client.websocket_connect("/site/ws/cursors") as ws:
+        ws.receive_json()
+        ws.send_json({"t": "cursor", "x": -3, "y": 9})
+        frame = ws.receive_json()
+    assert list(frame["c"].values()) == [[0.0, 1.0]]
+
+
+def test_ping_is_answered(client):
+    with client.websocket_connect("/site/ws/cursors") as ws:
+        ws.receive_json()
+        ws.send_json({"t": "ping"})
+        assert ws.receive_json() == {"t": "pong"}
+
+
+def test_a_stream_of_garbage_closes_the_connection(client):
+    with client.websocket_connect("/site/ws/cursors") as ws:
+        ws.receive_json()
+        for _ in range(cursors._MAX_INVALID_FRAMES):
+            ws.send_text("not json at all")
+        with pytest.raises(WebSocketDisconnect):
+            # Either a close frame or a disconnect — both mean the socket is gone.
+            for _ in range(3):
+                ws.receive_json()
+
+
+def test_a_single_bad_frame_is_survivable(client):
+    """Version skew and stray keepalives happen; one bad frame must not be fatal."""
+    with client.websocket_connect("/site/ws/cursors") as ws:
+        ws.receive_json()
+        ws.send_text("{oops")
+        ws.send_json({"t": "cursor", "x": 0.4, "y": 0.4})
+        frame = ws.receive_json()
+    assert list(frame["c"].values()) == [[0.4, 0.4]]
+
+
+def test_an_oversized_frame_is_not_parsed(client):
+    with client.websocket_connect("/site/ws/cursors") as ws:
+        ws.receive_json()
+        ws.send_json({"t": "cursor", "x": 0.1, "y": 0.1, "pad": "A" * cursors._MAX_FRAME_CHARS})
+        ws.send_json({"t": "cursor", "x": 0.6, "y": 0.6})
+        frame = ws.receive_json()
+    # The padded frame carried a valid position; it must still have been discarded.
+    assert list(frame["c"].values()) == [[0.6, 0.6]]
+
+
+def test_an_invalid_room_name_is_refused_at_the_handshake(client):
+    with pytest.raises(WebSocketDisconnect):
+        with client.websocket_connect("/site/ws/cursors?room=not a room") as ws:
+            ws.receive_json()
+
+
+def test_the_versioned_alias_serves_the_same_endpoint(client):
+    with client.websocket_connect("/v1/site/ws/cursors") as ws:
+        assert ws.receive_json()["t"] == "welcome"
+
+
+def test_stats_are_aggregate_only(client):
+    body = client.get("/site/cursors/stats").json()
+    # No room names and no IPs: this endpoint is unauthenticated, and a per-room
+    # breakdown would be a live feed of which pages are being read right now.
+    assert set(body) == {"connections", "rooms", "max_connections"}
+
+
+# --- origin ----------------------------------------------------------------
+
+def test_a_foreign_origin_is_refused(client):
+    with pytest.raises(WebSocketDisconnect):
+        with client.websocket_connect(
+            "/site/ws/cursors", headers={"origin": "https://evil.example.com"}
+        ) as ws:
+            ws.receive_json()
+
+
+def test_an_allowed_origin_gets_through(client):
+    with client.websocket_connect(
+        "/site/ws/cursors", headers={"origin": "https://vuhnger.dev"}
+    ) as ws:
+        assert ws.receive_json()["t"] == "welcome"
+
+
+def test_a_trailing_slash_on_the_origin_still_matches():
+    # Some clients send "https://vuhnger.dev/"; refusing it would be a real
+    # outage for a difference the browser considers cosmetic.
+    assert cors.is_allowed_origin("https://vuhnger.dev/")
+
+
+def test_a_missing_origin_is_allowed_outside_production_only(monkeypatch):
+    """WebSocket has no preflight, so Origin is the only signal we get. A request
+    without one is not a browser; in production there is no legitimate such client."""
+    monkeypatch.setattr(cors.settings, "environment", "development")
+    assert cors.is_allowed_origin(None) is True
+    monkeypatch.setattr(cors.settings, "environment", "production")
+    assert cors.is_allowed_origin(None) is False

--- a/tests/test_cursor_presence.py
+++ b/tests/test_cursor_presence.py
@@ -20,6 +20,7 @@ from starlette.websockets import WebSocketDisconnect, WebSocketState
 import apps.shared.cors as cors
 import apps.site.cursors as cursors
 import apps.site.main as site
+from apps.shared.config import Settings
 from apps.site.cursors import PALETTE, CursorHub, JoinRejected, _coord, _TokenBucket, _valid_room
 
 
@@ -376,3 +377,30 @@ def test_a_missing_origin_is_allowed_outside_production_only(monkeypatch):
     assert cors.is_allowed_origin(None) is True
     monkeypatch.setattr(cors.settings, "environment", "production")
     assert cors.is_allowed_origin(None) is False
+
+
+# --- regressions -----------------------------------------------------------
+
+def test_a_refused_join_closes_with_its_own_code(client, monkeypatch):
+    """The close code is the whole message. uvicorn tears down an endpoint that
+    returns without closing, but with 1006 (abnormal) — which every sane client
+    reads as a network glitch and answers by reconnecting. A peer refused on
+    policy would then retry forever against a cap that will never admit it."""
+    def refuse(**_):
+        raise JoinRejected("room_full", cursors.CLOSE_TRY_LATER)
+
+    monkeypatch.setattr(cursors.hub, "join", refuse)
+    with pytest.raises(WebSocketDisconnect) as excinfo:
+        with client.websocket_connect("/site/ws/cursors") as ws:
+            assert ws.receive_json() == {"t": "error", "code": "room_full"}
+            ws.receive_json()
+    assert excinfo.value.code == cursors.CLOSE_TRY_LATER
+
+
+@pytest.mark.parametrize("raw", ["nan", "inf", "1e999"])
+def test_non_finite_cursor_settings_are_refused_at_startup(raw, monkeypatch):
+    """`v <= 0` cannot catch these: every comparison against NaN is False, so a
+    typo'd CURSOR_TICK_HZ would reach the broadcast loop and sleep for NaN."""
+    monkeypatch.setenv("CURSOR_TICK_HZ", raw)
+    with pytest.raises(ValueError, match="finite"):
+        Settings()


### PR DESCRIPTION
Visitors on the same page see each other's cursors, multiplayer style.
`WS /site/ws/cursors`.

## Interface for the frontend

`frontend-examples/src/hooks/useCursors.ts` is a working client;
`frontend-examples/README.md` documents the full contract.

```
wss://api.vuhnger.dev/site/ws/cursors?room=<room>
```

| Direction | Message |
| --- | --- |
| → | `{"t":"cursor","x":0.51,"y":0.28}` viewport fractions, clamped to `[0,1]` |
| → | `{"t":"ping"}` |
| ← | `{"t":"welcome","id":..,"color":"#e11d48","peers":[..],"tick_hz":15,"idle_timeout_seconds":900}` |
| ← | `{"t":"join"/"leave","id":..}` |
| ← | `{"t":"frame","c":{"<id>":[x,y]}}` only peers that moved this tick |
| ← | `{"t":"error","code":".."}` sent just before a close |

Colour is assigned server-side so every client agrees on who is who — two
browsers picking their own would sometimes pick the same one. Ignore it and
render your own if you prefer.

## Why it is built this way

**Fan-out is batched.** Broadcasting per message is O(n²): twenty peers at 60 Hz
is 24k messages/s. Each peer's latest position is stored and one loop per room
emits a single combined frame at `CURSOR_TICK_HZ`. Measured against a real
uvicorn: 100 updates in → 32 frames out, 50-byte payloads.

**Every limit lives in the hub, because it has to.** The shared middleware stack
is registered with `@app.middleware("http")` and never sees a WebSocket scope —
so the per-IP, per-room and global caps here are not defence in depth, they are
the only defence. Same reason `Origin` is checked explicitly: browsers send it on
a WS handshake but enforce nothing themselves (CSWSH).

**Single worker.** The hub is in-memory, the same precondition the in-memory rate
limiter already documents. Two workers would split each room in half. Scaling
past one means Redis pub/sub, not a bigger box.

## Verified against a real server

| | |
| --- | --- |
| 3 peers, distinct colours, join/frame/leave | ✅ |
| 100 updates at 50 Hz → 32 frames | ✅ 3.1:1 collapse, at the configured 15 Hz |
| 300 updates as fast as the socket allows | ✅ closed 1008 |
| `Origin: https://evil.example.com` | ✅ HTTP 403, never reaches `accept()` |
| per-IP cap | ✅ 4th tab refused, `too_many_connections` |
| SIGTERM with 3 open sockets | ✅ clean in 0.09 s |

53 new tests. Full suite 200 passed, ruff and mypy clean.

## Also in here

- `create_app()` takes an optional `lifespan`; the site app uses it to cancel
  room loops, which uvicorn knows nothing about
- `--timeout-graceful-shutdown 5` on `site-api` only — uvicorn waits indefinitely
  by default, fine for request/response, not for a service holding long-lived
  sockets
- `site-api` added to the dev compose stack; it was prod-only, so neither the
  visit beacon nor this was runnable locally

## CodeRabbit

5 findings, all fixed and individually verified. One diagnosis was off: the
refused-join path was reported as leaking a socket, but uvicorn closes it anyway
— with `1006`, the code a client reads as "retry". The real bug was a policy
rejection turning into an infinite reconnect, and the same fix closes it.